### PR TITLE
refactor(util): move LoadingBar from cli to util and update imports\n…

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/BookCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/BookCommands.java
@@ -11,6 +11,7 @@ import com.penrose.bibby.library.bookcase.BookcaseService;
 import com.penrose.bibby.library.shelf.ShelfEntity;
 import com.penrose.bibby.library.shelf.ShelfService;
 
+import com.penrose.bibby.util.LoadingBar;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.component.flow.ComponentFlow;
 import org.springframework.shell.standard.AbstractShellComponent;

--- a/src/main/java/com/penrose/bibby/util/LoadingBar.java
+++ b/src/main/java/com/penrose/bibby/util/LoadingBar.java
@@ -1,4 +1,4 @@
-package com.penrose.bibby.cli;
+package com.penrose.bibby.util;
 
 public class LoadingBar {
 


### PR DESCRIPTION
This pull request makes a minor change to the organization of the codebase by moving the `LoadingBar` class to a new package and updating its import in `BookCommands.java`.

- Refactored code organization:
  * Moved the `LoadingBar` class from the `com.penrose.bibby.cli` package to the new `com.penrose.bibby.util` package and updated its import in `BookCommands.java` to reflect the new location. [[1]](diffhunk://#diff-4183815ed9e1e835baef380461736c293b277e85cfff0bffba995bb34d2a6e5aL1-R1) [[2]](diffhunk://#diff-695dac1918ae44efeed4f5e69414b9a5c716350528b7aabcc1ce3c627f80ca3aR14)…\nRelocate LoadingBar to util package for better organization and reuse.\nUpdate BookCommands to import com.penrose.bibby.util.LoadingBar.\n\nNo functional changes.