### PR TITLE
refactor(book): use Optional for findByTitleIgnoreCase

### DIFF
--- a/src/main/java/com/penrose/bibby/library/book/BookRepository.java
+++ b/src/main/java/com/penrose/bibby/library/book/BookRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BookRepository extends JpaRepository <BookEntity, Long> {
@@ -15,7 +16,7 @@ public interface BookRepository extends JpaRepository <BookEntity, Long> {
 
     BookEntity findByTitle(String title);
 
-    BookEntity findByTitleIgnoreCase(String title);
+    Optional<BookEntity> findByTitleIgnoreCase(String title);
 
     List<BookEntity> findByTitleContaining(String title);
 


### PR DESCRIPTION
This pull request refactors how books are found by title in the `BookRepository` and `BookService` classes, improving null safety and error handling by switching to `Optional<BookEntity>` for case-insensitive title lookups. The changes also streamline book creation logic to prevent duplicate entries.

Repository and Service API improvements:

* Changed the return type of `findByTitleIgnoreCase` in `BookRepository` and `BookService` from `BookEntity` to `Optional<BookEntity>`, ensuring better handling of absent results. [[1]](diffhunk://#diff-6c1541242e68b0c127fe9724cfc1c3a943bd61a0cf4f00c0b6632c26da8a1627L18-R19) [[2]](diffhunk://#diff-99bcf432c2366daab07f071891a78ffdb3c30302d130fd02cf5eefd4459d3111L94-R93)
* Updated usages of `findByTitleIgnoreCase` in `BookService` to work with `Optional`, replacing manual null checks with `Optional` methods for improved code clarity and safety.

Book creation logic enhancements:

* Modified `createNewBook` in `BookService` to throw an `IllegalArgumentException` if a book with the same title already exists, preventing duplicate entries and making error handling more explicit.

Imports and code cleanup:

* Added missing `Optional` import and removed unused code in `BookService.java` to support the new method signatures and improve code hygiene.

These changes make the codebase more robust and idiomatic by leveraging `Optional` for absent values and enforcing uniqueness constraints during book creation.- Updated BookRepository to return Optional<BookEntity> instead of BookEntity
- Refactored BookService methods to handle Optional properly
- Improved createNewBook logic to throw exception if book already exists
- Simplified findBookByTitle by using Optional.orElse(null)