### PR TITLE
refactor(book): clean up constructors and imports, improve equals and…

### DIFF
--- a/src/main/java/com/penrose/bibby/library/book/Book.java
+++ b/src/main/java/com/penrose/bibby/library/book/Book.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 import com.penrose.bibby.library.author.AuthorEntity;
 import com.penrose.bibby.library.genre.Genre;
-import com.penrose.bibby.library.shelf.*;
+import com.penrose.bibby.library.shelf.Shelf;
 
 public class Book {
     private Long id;
@@ -23,6 +23,14 @@ public class Book {
     private LocalDate createdAt;
     private LocalDate updatedAt;
 
+    public Book() {
+    }
+
+    public Book(Long id, String title, AuthorEntity authorEntity) {
+        this.id = id;
+        this.title = title;
+        this.authorEntity = authorEntity;
+    }
 
     public String getDescription() {
         return description;
@@ -30,16 +38,6 @@ public class Book {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public Book(){
-
-    }
-
-    public Book(Long id, String title, AuthorEntity authorEntity) {
-        this.id = id;
-        this.title = title;
-        this.authorEntity = authorEntity;
     }
 
     public Long getId() {
@@ -154,7 +152,7 @@ public class Book {
                 ", author=" + authorEntity +
                 ", isbn='" + isbn + '\'' +
                 ", publisher='" + publisher + '\'' +
-                ", publicationYear='" + publicationYear + '\'' +
+                ", publicationYear=" + publicationYear +
                 ", genre=" + genre +
                 ", shelf=" + shelf +
                 ", description='" + description + '\'' +
@@ -167,6 +165,7 @@ public class Book {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Book book = (Book) o;
         return Objects.equals(id, book.id);

--- a/src/main/java/com/penrose/bibby/library/book/BookService.java
+++ b/src/main/java/com/penrose/bibby/library/book/BookService.java
@@ -96,12 +96,7 @@ public class BookService {
         bookRepository.save(bookEntity);
     }
 
-    /**
-     * Updates the status of a book to "CHECKED_OUT" if it is not already checked out.
-     * The method will persist the status change in the data store.
-     *
-     * @param bookEntity the book entity to be checked out
-     */
+
     public void checkOutBook(BookEntity bookEntity){
         if(!bookEntity.getBookStatus().equals(BookStatus.CHECKED_OUT.toString())){
             bookEntity.setBookStatus("CHECKED_OUT");


### PR DESCRIPTION
This pull request makes several updates to the `Book` class and related service code, focusing on code organization, method placement, and minor logic improvements. The most significant changes are the relocation of the `getDescription` and `setDescription` methods within the `Book` class, a fix to the `toString` method, and a minor logic improvement in the `equals` method.

**Book class refactoring and improvements:**

* Moved the `getDescription` and `setDescription` methods from the top of the `Book` class to a location after the constructor, improving code organization and readability. [[1]](diffhunk://#diff-dd84265702015d0fcdc558611e4cd41efcca33294408b368515f60cfe7656a91L26-L36) [[2]](diffhunk://#diff-dd84265702015d0fcdc558611e4cd41efcca33294408b368515f60cfe7656a91R35-R42)
* Fixed the `toString` method to display `publicationYear` as an integer rather than as a string, ensuring proper formatting.
* Improved the `equals` method by adding a self-comparison check (`if (this == o) return true;`), which can improve performance and correctness.

**Code cleanup:**

* Updated the import statement for `Shelf` to import only the required class, reducing unnecessary imports.
* Removed redundant method documentation for `checkOutBook` in `BookService`, streamlining the code.… toString

- Replace wildcard shelf import with explicit Shelf import
- Consolidate and reorder Book constructors for clarity
- Update toString to print publicationYear as numeric instead of string
- Add self-check in equals method for performance
- Remove redundant Javadoc in BookService.checkOutBook