### PR TITLE
 refactor(Book): replace AuthorEntity with List<Author>

### DIFF
--- a/src/main/java/com/penrose/bibby/library/book/Book.java
+++ b/src/main/java/com/penrose/bibby/library/book/Book.java
@@ -1,9 +1,10 @@
 package com.penrose.bibby.library.book;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Objects;
 
-import com.penrose.bibby.library.author.AuthorEntity;
+import com.penrose.bibby.library.author.Author;
 import com.penrose.bibby.library.genre.Genre;
 import com.penrose.bibby.library.shelf.Shelf;
 
@@ -11,10 +12,7 @@ public class Book {
     private Long id;
     private int edition;
     private String title;
-    //Why does my Book DOMAIN model not have an Author? But an AuthorEntity?
-    //AuthorEntry should probably be a Domain Model and not an Entity.
-    //Mixing Layers.
-    private AuthorEntity authorEntity;
+    private List<Author> authors;
     private String isbn;
     private String publisher;
     private int publicationYear;
@@ -29,10 +27,10 @@ public class Book {
     public Book() {
     }
 
-    public Book(Long id, String title, AuthorEntity authorEntity) {
+    public Book(Long id, String title, List<Author> authors) {
         this.id = id;
         this.title = title;
-        this.authorEntity = authorEntity;
+        this.authors = authors;
     }
     
     public void checkout(){
@@ -74,12 +72,12 @@ public class Book {
         this.title = title;
     }
 
-    public AuthorEntity getAuthor() {
-        return authorEntity;
+    public List<Author> getAuthors() {
+        return authors;
     }
 
-    public void setAuthor(AuthorEntity authorEntity) {
-        this.authorEntity = authorEntity;
+    public void addAuthors(Author author) {
+        authors.add(author);
     }
 
     public String getIsbn() {
@@ -166,15 +164,16 @@ public class Book {
     public String toString() {
         return "Book{" +
                 "id=" + id +
+                ", edition=" + edition +
                 ", title='" + title + '\'' +
-                ", author=" + authorEntity +
+                ", authors=" + authors +
                 ", isbn='" + isbn + '\'' +
                 ", publisher='" + publisher + '\'' +
                 ", publicationYear=" + publicationYear +
                 ", genre=" + genre +
                 ", shelf=" + shelf +
                 ", description='" + description + '\'' +
-                ", status=" + availabilityStatus +
+                ", availabilityStatus=" + availabilityStatus +
                 ", checkoutCount=" + checkoutCount +
                 ", createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +


### PR DESCRIPTION
This pull request updates the `Book` domain model to improve how authors are represented and managed. The main change is replacing the single `AuthorEntity` field with a list of `Author` objects, allowing each book to have multiple authors and aligning the model with proper domain-driven design principles.

**Domain model improvements:**

* Changed the `Book` class to use a `List<Author>` instead of a single `AuthorEntity`, allowing multiple authors per book and removing the mixing of entity and domain layers.
* Updated the constructor to accept a list of authors, and replaced the `getAuthor` and `setAuthor` methods with `getAuthors` and `addAuthors` for managing multiple authors. [[1]](diffhunk://#diff-dd84265702015d0fcdc558611e4cd41efcca33294408b368515f60cfe7656a91L32-R33) [[2]](diffhunk://#diff-dd84265702015d0fcdc558611e4cd41efcca33294408b368515f60cfe7656a91L77-R80)

**Code consistency and clarity:**

* Modified the `toString` method to correctly display the list of authors and improved naming consistency for the availability status field.- Updated Book domain model to use List<Author> instead of AuthorEntity
- Adjusted constructors, getters, and setters accordingly
- Improved toString() output to reflect multiple authors
- Removed comments about mixing domain and entity layers