### PR TITLE
refactor: remove business logic dependencies from CliPromptService

### DIFF
--- a/docs/mentor-feedback/2025-11-24-cli-prompt-service-refactor.md
+++ b/docs/mentor-feedback/2025-11-24-cli-prompt-service-refactor.md
@@ -1,0 +1,61 @@
+Nice work, Leo! This is a solid architectural improvement. Let me give you detailed feedback on what you've done well and where there's an opportunity to polish further.
+
+## What You Did Right ✓
+
+**1. Improved Separation of Concerns** You correctly identified that `CliPromptService` was doing too much - it was both handling UI prompts AND fetching business data. By removing the `BookcaseService` dependency, you've made `CliPromptService` focus purely on presentation concerns (showing menus, collecting input). This is exactly the kind of architectural thinking that scales well.
+
+**2. Dependency Inversion in Action** By changing `promptForBookCase()` to accept a `Map<String, String>` parameter, you're letting the caller decide where the data comes from. This makes `CliPromptService` more reusable and testable. It no longer cares about bookcases - it just cares about displaying options.
+
+**3. Cleaned Up Unused Dependencies** Good catch removing the unused `authorMapperTwo` field from `BookDomainRepositoryImpl`. These small cleanups matter!
+
+## The One Issue: Code Duplication 🤔
+
+I noticed you now have `bookCaseOptions()` in **both** `BookCommands` and `BookcaseCommands`. They appear to be identical:
+
+```java
+// In BookCommands
+private Map<String, String> bookCaseOptions() {
+    Map<String, String> options = new LinkedHashMap<>();
+    List<BookcaseEntity> bookcaseEntities = bookcaseService.getAllBookcases();
+    for(BookcaseEntity b : bookcaseEntities){
+        options.put(b.getBookcaseLabel(), b.getBookcaseId().toString());
+    }
+    return options;
+}
+
+// Same method also exists in BookcaseCommands
+```
+
+This is a code smell. Here are your options:
+
+**Option 1: Create a Shared Helper/Utility Class** (My recommendation)
+
+```java
+// BookcaseMenuHelper.java or similar
+@Component
+public class BookcaseMenuHelper {
+    private final BookcaseService bookcaseService;
+    
+    public Map<String, String> buildBookcaseOptions() {
+        // ... implementation
+    }
+}
+```
+
+Then inject it into both command classes.
+
+**Option 2: Have BookCommands Delegate to BookcaseCommands** Since `BookcaseCommands` "owns" the bookcase domain, you could make its method protected/public and have `BookCommands` call it. But this creates coupling between command classes, which feels awkward.
+
+**Option 3: Accept Some Duplication** Sometimes a little duplication is okay if the methods might evolve differently. Ask yourself: "Will these two methods always stay identical, or might they diverge?" If they might show different bookcase options based on context, keep them separate.
+
+## Questions for You to Think About:
+
+1. **Who "owns" the logic for building bookcase options?** Is it a UI concern (belongs with commands) or a service concern (belongs with BookcaseService)?
+2. **Will these methods always be identical?** Or might `BookCommands` someday need to filter bookcases differently than `BookcaseCommands`?
+3. **What's the trade-off?** A helper class adds another file but eliminates duplication. Duplication is simpler now but risky if you need to change the logic later.
+
+## Bottom Line
+
+Your refactoring demonstrates solid architectural instincts - you saw that `CliPromptService` had too many responsibilities and fixed it. The duplication issue is minor but worth addressing. I'd lean toward a small helper class since building UI options from domain entities feels like a cross-cutting concern, but you know your codebase best.
+
+What's your intuition here? Do you think these methods will stay identical, or might they need to differ?

--- a/src/main/java/com/penrose/bibby/cli/BookCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/BookCommands.java
@@ -113,7 +113,7 @@ public class BookCommands extends AbstractShellComponent {
         if(bookEnt == null){
             System.out.println("Book Not Found In Library");
         }else {
-            Long bookCaseId = cliPrompt.promptForBookCase();
+            Long bookCaseId = cliPrompt.promptForBookCase(bookCaseOptions());
             Long shelfId = cliPrompt.promptForShelf(bookCaseId);
 //            System.out.println(shelfId);
 //            System.out.println(title);
@@ -368,4 +368,16 @@ public class BookCommands extends AbstractShellComponent {
     public void suggestBookShelf(){
         System.out.println("Book should be placed on Shelf: G-16");
     }
+
+    private Map<String, String> bookCaseOptions() {
+        // LinkedHashMap keeps insertion order so the menu shows in the order you add them
+        Map<String, String> options = new LinkedHashMap<>();
+        List<BookcaseEntity> bookcaseEntities  = bookcaseService.getAllBookcases();
+        for(BookcaseEntity b : bookcaseEntities){
+            options.put(b.getBookcaseLabel(), b.getBookcaseId().toString());
+        }
+
+        return options;
+    }
+
 }

--- a/src/main/java/com/penrose/bibby/cli/BookcaseCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/BookcaseCommands.java
@@ -38,10 +38,10 @@ public class BookcaseCommands extends AbstractShellComponent {
     }
 
     public String bookcaseRowFormater(BookcaseEntity bookcaseEntity, int bookCount){
-        return String.format(" %-12s \u001B[1m\u001B[38;5;63m%-2d\u001B[22m\u001B[38;5;15mShelves    \u001B[1m\u001B[38;5;63m%-2d\u001B[22m\u001B[38;5;15mBooks ", bookcaseEntity.getBookcaseLabel().toUpperCase(),bookcaseEntity.getShelfCapacity(),bookCount);
+        return String.format(" %-20s \u001B[1m\u001B[38;5;63m%-2d\u001B[22m\u001B[38;5;15mShelves    \u001B[1m\u001B[38;5;63m%-3d\u001B[22m\u001B[38;5;15mBooks", bookcaseEntity.getBookcaseLabel().toUpperCase(),bookcaseEntity.getShelfCapacity(),bookCount);
     }
 
-    @Command(command = "add", description = "Create a new bookcase in the library.")
+    @Command(command = "create", description = "Create a new bookcase in the library.")
     public void addBookcase() throws InterruptedException {
 
 
@@ -98,6 +98,7 @@ public class BookcaseCommands extends AbstractShellComponent {
       }else{
           System.out.println("Not Created");
       }
+
 
 
     }
@@ -221,6 +222,8 @@ public class BookcaseCommands extends AbstractShellComponent {
         }
 
     }
+
+
 
 
 

--- a/src/main/java/com/penrose/bibby/cli/CliPromptService.java
+++ b/src/main/java/com/penrose/bibby/cli/CliPromptService.java
@@ -15,13 +15,11 @@ import java.util.Map;
 @Component
 public class CliPromptService {
     private final ComponentFlow.Builder componentFlowBuilder;
-    private final BookcaseService bookcaseService;
     private final ShelfService shelfService;
 
     public CliPromptService(ComponentFlow.Builder componentFlowBuilder, ComponentFlow.Builder componentFlowBuilder1, BookcaseService bookcaseService, ShelfService shelfService) {
 
         this.componentFlowBuilder = componentFlowBuilder1;
-        this.bookcaseService = bookcaseService;
         this.shelfService = shelfService;
     }
 
@@ -65,12 +63,12 @@ public class CliPromptService {
         return Long.parseLong(result.getContext().get("bookshelf",String.class));
     }
 
-    public Long promptForBookCase(){
+    public Long promptForBookCase(Map<String, String> bookCaseOptions){
         ComponentFlow flow;
         flow = componentFlowBuilder.clone()
                 .withSingleItemSelector("bookcase")
                 .name("Choose a Bookcase:_")
-                .selectItems(bookCaseOptions())
+                .selectItems(bookCaseOptions)
                 .and().build();
         ComponentFlow.ComponentFlowResult result = flow.run();
         return Long.parseLong(result.getContext().get("bookcase",String.class));
@@ -115,25 +113,22 @@ public class CliPromptService {
     private Map<String, String> buildSearchOptions() {
         // LinkedHashMap keeps insertion order so the menu shows in the order you add them
         Map<String, String> options = new LinkedHashMap<>();
-        options.put("Show all books  — \u001B[32mView the complete library\n\u001B[0m", "all");
-        options.put("Title or keyword  —  \u001B[32mSearch by words in the title\n\u001B[0m", "title");
-        options.put("Author  —  \u001B[32mFind books by author name\n\u001B[0m", "author");
-        options.put("Genre  —  \u001B[32mFilter books by literary category\n\u001B[0m", "genre");
-        options.put("Shelf/Location  —  \u001B[32mLocate books by physical shelf ID\n\u001B[0m", "shelf");
-        options.put("Status  — \u001B[32mShow available or checked-out books\n\u001B[0m", "status");
+        options.put("""
+                        Show all books       (View the complete library)""", "all");
+        options.put("""
+                        Title or keyword     (Search by words in the title)""", "title");
+        options.put("""
+                        Author               (Find books by author name)""", "author");
+        options.put("""
+                        Genre                (Filter books by literary category)""", "genre");
+        options.put("""
+                        Shelf/Location       (Locate books by physical shelf ID)""", "shelf");
+        options.put("""
+                        Status               (Show available or checked-out books)""", "status");
         return options;
     }
 
-    private Map<String, String> bookCaseOptions() {
-        // LinkedHashMap keeps insertion order so the menu shows in the order you add them
-        Map<String, String> options = new LinkedHashMap<>();
-        List<BookcaseEntity> bookcaseEntities  = bookcaseService.getAllBookcases();
-        for(BookcaseEntity b : bookcaseEntities){
-            options.put(b.getBookcaseLabel(), b.getBookcaseId().toString());
-        }
 
-        return options;
-    }
 
     private Map<String, String> bookShelfOptions(Long bookcaseId) {
         // LinkedHashMap keeps insertion order so the menu shows in the order you add them

--- a/src/main/java/com/penrose/bibby/library/book/BookDomainRepositoryImpl.java
+++ b/src/main/java/com/penrose/bibby/library/book/BookDomainRepositoryImpl.java
@@ -11,14 +11,12 @@ public class BookDomainRepositoryImpl implements BookDomainRepository{
     private final BookMapperTwo bookMapperTwo;
     private final BookRepository bookRepository;
     private final AuthorRepository authorRepository;
-    private final AuthorMapperTwo authorMapperTwo;
 
-    public BookDomainRepositoryImpl(BookMapperTwo bookMapperTwo, BookRepository bookRepository, AuthorRepository authorRepository, AuthorMapperTwo authorMapperTwo) {
+    public BookDomainRepositoryImpl(BookMapperTwo bookMapperTwo, BookRepository bookRepository, AuthorRepository authorRepository) {
         this.bookMapperTwo = bookMapperTwo;
 
         this.bookRepository = bookRepository;
         this.authorRepository = authorRepository;
-        this.authorMapperTwo = authorMapperTwo;
     }
 
     @Override


### PR DESCRIPTION
This pull request introduces an architectural refactor that improves separation of concerns in the CLI prompt and command services. The main change is delegating bookcase option building to the command classes instead of `CliPromptService`, making the prompt service UI-focused and more testable. Additionally, unused dependencies are cleaned up, and some UI formatting and command naming are improved. The changes also introduce some code duplication related to bookcase option building, which is noted for future consideration.

**Architectural improvements:**

* Refactored `CliPromptService` to remove its dependency on `BookcaseService` and delegate bookcase option building to callers, making the service focused solely on UI/presentation logic. (`src/main/java/com/penrose/bibby/cli/CliPromptService.java`) [[1]](diffhunk://#diff-4887dde97f1637e4b75521370c43cbb7bcd6180562f1a65821b152c88f39e835L18-L24) [[2]](diffhunk://#diff-4887dde97f1637e4b75521370c43cbb7bcd6180562f1a65821b152c88f39e835L68-R71) [[3]](diffhunk://#diff-4887dde97f1637e4b75521370c43cbb7bcd6180562f1a65821b152c88f39e835L118-L136)
* Updated `BookCommands` and `BookcaseCommands` to include identical `bookCaseOptions()` methods for building bookcase selection options, resulting in code duplication that should be addressed in future refactors. (`src/main/java/com/penrose/bibby/cli/BookCommands.java`, `src/main/java/com/penrose/bibby/cli/BookcaseCommands.java`) [[1]](diffhunk://#diff-695dac1918ae44efeed4f5e69414b9a5c716350528b7aabcc1ce3c627f80ca3aR371-R382) [[2]](diffhunk://#diff-1ce0e44715d54c3e3a8ae430137d5b0f391dc45c465bbb345adc806f1155033fR103)

**Dependency cleanup:**

* Removed the unused `authorMapperTwo` field and constructor parameter from `BookDomainRepositoryImpl`, streamlining repository dependencies. (`src/main/java/com/penrose/bibby/library/book/BookDomainRepositoryImpl.java`)

**UI and command improvements:**

* Improved formatting in the `bookcaseRowFormater` method for better display and renamed the bookcase creation command from `"add"` to `"create"` for clarity. (`src/main/java/com/penrose/bibby/cli/BookcaseCommands.java`)
* Updated search option text in `CliPromptService` for clearer and more consistent menu descriptions. (`src/main/java/com/penrose/bibby/cli/CliPromptService.java`)

**Documentation and feedback:**

* Added detailed mentor feedback documenting the architectural improvements, highlighting the benefits and raising questions about code duplication and ownership of option-building logic. (`docs/mentor-feedback/2025-11-24-cli-prompt-service-refactor.md`)Improved separation of concerns by removing BookcaseService dependency from CliPromptService, making it focus solely on UI prompt handling.

Changes:
- Modified promptForBookCase() to accept Map<String,String> parameter instead of fetching bookcase data directly
- Moved bookCaseOptions() method from CliPromptService to BookCommands
- Removed unused BookcaseService field from CliPromptService
- Removed unused authorMapperTwo field from BookDomainRepositoryImpl
- Changed bookcase command from add to create for consistency
- Improved formatting in bookcaseRowFormater and buildSearchOptions

This change makes CliPromptService more reusable and testable by inverting the dependency - callers now provide the options to display rather than the service fetching them.