### PR TITLE
feat(book): integrate Google Books API with enrichment service

### DIFF
--- a/docs/the-devlogs/devlog-2025-12-01-book-enrichment.md
+++ b/docs/the-devlogs/devlog-2025-12-01-book-enrichment.md
@@ -1,0 +1,77 @@
+# Dev Log: Google Books Enrichment Integration
+
+**Date:** 2025-12-01  
+**Branch:** feature/book-enrichment (or main)
+
+---
+
+## Summary
+
+Completed the integration between the Google Books API lookup and book data enrichment. The system now properly deserializes API responses into domain objects and enriches book metadata automatically when scanning ISBNs.
+
+## Changes Made
+
+### 1. Proper Response Deserialization (BookInfoService)
+Replaced raw `String` response handling with typed deserialization:
+- `lookupBook()` now returns `Mono<GoogleBooksResponse>` instead of `Mono<String>`
+- WebClient uses `bodyToMono(GoogleBooksResponse.class)` for automatic JSON mapping
+
+### 2. Controller Integration (BookController)
+- Injected `BookEnrichmentService` dependency
+- Updated `/lookup/{isbn}` endpoint to return typed `GoogleBooksResponse`
+- Wired enrichment into the reactive chain via `doOnNext()`
+
+### 3. Domain Model Enhancement (Book)
+- Added `publishedDate` field with getter/setter
+- Expanded `toString()` for better debugging output (now includes isbn, publisher, description, availabilityStatus, shelf)
+
+### 4. Factory Pattern Extension (AuthorFactory)
+- Added `create(String firstName, String lastName)` method returning domain `Author` object
+- Maintains existing `createEntity()` for persistence layer
+
+## Technical Notes
+
+The reactive chain in the controller now flows:
+```
+ISBN scan → BookInfoService.lookupBook() → GoogleBooksResponse → BookEnrichmentService.enrichBookData()
+```
+
+Using `doOnNext()` for the enrichment side-effect keeps the response flowing to the client while processing occurs. This is appropriate for fire-and-forget enrichment but worth revisiting if we need to wait for enrichment completion before responding.
+
+## What's Working
+
+Screenshot confirms end-to-end flow:
+- Webcam barcode scanner captures ISBN (9781449373320)
+- Google Books API returns metadata for "Designing Data-Intensive Applications"
+- Author parsing correctly extracts "Martin Kleppmann"
+- Enrichment service receives and processes the data
+
+## Next Steps
+
+- [ ] Persist enriched book data to database
+- [ ] Handle cases where Google Books returns multiple items
+- [ ] Add error handling for API failures/timeouts
+- [ ] Consider whether `doOnNext()` should become `flatMap()` if we need enrichment to complete before response
+
+---
+
+## Commit Message
+
+```
+feat(book): integrate Google Books API with enrichment service
+
+- Replace String response with typed GoogleBooksResponse deserialization
+- Wire BookEnrichmentService into lookup endpoint reactive chain
+- Add publishedDate field to Book domain model
+- Extend AuthorFactory with domain object creation method
+- Expand Book.toString() for improved debugging
+
+The /lookup/{isbn} endpoint now returns structured book metadata
+and triggers automatic enrichment when ISBNs are scanned.
+```
+
+---
+
+## Reflection
+
+This marks the transition from "proof of concept" (raw JSON strings) to "production-ready patterns" (typed domain objects, proper service boundaries). The factory pattern extension for Author keeps entity/domain separation clean - we can create domain objects for business logic without coupling to JPA.

--- a/src/main/java/com/penrose/bibby/library/author/AuthorFactory.java
+++ b/src/main/java/com/penrose/bibby/library/author/AuthorFactory.java
@@ -5,6 +5,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthorFactory {
 
+    public Author create(String firstName, String lastName){
+        return new Author(firstName, lastName);
+    }
+
     public AuthorEntity createEntity(String firstName, String lastName){
         return new AuthorEntity(firstName, lastName);
     }

--- a/src/main/java/com/penrose/bibby/library/book/domain/Book.java
+++ b/src/main/java/com/penrose/bibby/library/book/domain/Book.java
@@ -22,6 +22,7 @@ public class Book {
     private AvailabilityStatus availabilityStatus;
     private LocalDate createdAt;
     private LocalDate updatedAt;
+    private String publishedDate;
 
     public Book() {
     }
@@ -54,6 +55,14 @@ public class Book {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getPublishedDate() {
+        return publishedDate;
+    }
+
+    public void setPublishedDate(String publishedDate) {
+        this.publishedDate = publishedDate;
     }
 
     public Long getId() {
@@ -158,8 +167,16 @@ public class Book {
 
     @Override
     public String toString() {
-        return "Book{ title='" + title + '\'' +
+        return "Book{" +
+                "title='" + title + '\'' +
                 ", authors=" + authors +
+                ", isbn='" + isbn + '\'' +
+                ", publisher='" + publisher + '\'' +
+                ", description='" + description + '\'' +
+                ", availabilityStatus=" + availabilityStatus +
+                ", publishedDate='" + publishedDate + '\'' +
+                ", updatedAt=" + updatedAt +
+                ", shelf=" + shelf +
                 '}';
     }
 

--- a/src/main/java/com/penrose/bibby/library/book/domain/BookMetaData.java
+++ b/src/main/java/com/penrose/bibby/library/book/domain/BookMetaData.java
@@ -1,0 +1,5 @@
+package com.penrose.bibby.library.book.domain;
+
+
+public record BookMetaData(String title, String[] authors, String publisher, String description, String isbn_13, String[] categories) {
+}

--- a/src/main/java/com/penrose/bibby/library/book/domain/GoogleBookItems.java
+++ b/src/main/java/com/penrose/bibby/library/book/domain/GoogleBookItems.java
@@ -1,0 +1,4 @@
+package com.penrose.bibby.library.book.domain;
+
+public record GoogleBookItems(VolumeInfo volumeInfo) {
+}

--- a/src/main/java/com/penrose/bibby/library/book/domain/GoogleBooksResponse.java
+++ b/src/main/java/com/penrose/bibby/library/book/domain/GoogleBooksResponse.java
@@ -1,0 +1,6 @@
+package com.penrose.bibby.library.book.domain;
+
+import java.util.List;
+
+public record GoogleBooksResponse(List<GoogleBookItems> items) {
+}

--- a/src/main/java/com/penrose/bibby/library/book/domain/VolumeInfo.java
+++ b/src/main/java/com/penrose/bibby/library/book/domain/VolumeInfo.java
@@ -1,0 +1,14 @@
+package com.penrose.bibby.library.book.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record VolumeInfo(String title,
+                         List<String> authors,
+                         String publisher,
+                         String description,
+                         String isbn,
+                         List<String> categories,
+                         String publishedDate
+                        ) {
+}

--- a/src/main/java/com/penrose/bibby/library/book/service/BookEnrichmentService.java
+++ b/src/main/java/com/penrose/bibby/library/book/service/BookEnrichmentService.java
@@ -1,0 +1,53 @@
+package com.penrose.bibby.library.book.service;
+
+import com.penrose.bibby.library.author.Author;
+import com.penrose.bibby.library.author.AuthorFactory;
+import com.penrose.bibby.library.book.domain.Book;
+import com.penrose.bibby.library.book.domain.BookFactory;
+import com.penrose.bibby.library.book.domain.BookMetaData;
+import com.penrose.bibby.library.book.domain.GoogleBooksResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+
+@Service
+public class BookEnrichmentService {
+
+    private static final Logger log = LoggerFactory.getLogger(BookEnrichmentService.class);
+    AuthorFactory authorFactory;
+
+
+
+    public BookEnrichmentService(AuthorFactory authorFactory) {
+        this.authorFactory = authorFactory;
+    }
+
+    public void enrichBookData(GoogleBooksResponse bookMetaData, String isbn){
+        // Placeholder for future implementation
+        HashSet<Author> authors = new HashSet<>();
+
+        Book book = new Book();
+        for(String authorName : bookMetaData.items().get(0).volumeInfo().authors()) {
+            String [] nameParts = authorName.split(" ", 2);
+            Author author = new Author();
+            author.setFirstName(nameParts[0]);
+            author.setLastName(nameParts[1]);
+            authors.add(author);
+            book.setAuthors(authors);
+        }
+        book.setTitle(bookMetaData.items().get(0).volumeInfo().title());
+        book.setPublisher(bookMetaData.items().get(0).volumeInfo().publisher());
+        book.setDescription(bookMetaData.items().get(0).volumeInfo().description());
+        book.setIsbn(isbn);
+        book.setPublishedDate(bookMetaData.items().get(0).volumeInfo().publishedDate());
+
+        log.info("\nEnriched book data for: {}", book.getTitle());
+        log.info(String.valueOf(book));
+
+    }
+
+
+
+}

--- a/src/main/java/com/penrose/bibby/library/book/service/BookInfoService.java
+++ b/src/main/java/com/penrose/bibby/library/book/service/BookInfoService.java
@@ -1,5 +1,6 @@
 package com.penrose.bibby.library.book.service;
 
+import com.penrose.bibby.library.book.domain.GoogleBooksResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -13,12 +14,12 @@ public class BookInfoService {
     }
 
 
-    public Mono<String> lookupBook(String isbn){
+    public Mono<GoogleBooksResponse> lookupBook(String isbn){
         String url = "https://www.googleapis.com/books/v1/volumes?q=isbn:"+(isbn);
         return webClient.get()
                 .uri(url)
                 .retrieve()
-                .bodyToMono(String.class);
+                .bodyToMono(GoogleBooksResponse.class);
     }
 
 }


### PR DESCRIPTION
This pull request completes the integration of Google Books API with the book enrichment service, moving from raw JSON handling to typed domain objects and automating metadata enrichment when scanning ISBNs. The changes improve data modeling, controller logic, and service boundaries, laying the groundwork for future persistence and error handling.

**API Integration and Controller Logic:**
* The `/lookup/{isbn}` endpoint in `BookController` now returns a typed `GoogleBooksResponse` and triggers automatic enrichment via `BookEnrichmentService`, using a reactive chain and side-effect with `doOnNext()` for fire-and-forget enrichment. [[1]](diffhunk://#diff-92d63d7d77e0b672fe1dfd8b232bdf03210234978c6558bcd6b3da096e3b5b96L32-R40) [[2]](diffhunk://#diff-92d63d7d77e0b672fe1dfd8b232bdf03210234978c6558bcd6b3da096e3b5b96R4-R7) [[3]](diffhunk://#diff-92d63d7d77e0b672fe1dfd8b232bdf03210234978c6558bcd6b3da096e3b5b96R20-R26)

**Domain Model Enhancements:**
* Added a `publishedDate` field to the `Book` domain model, with corresponding getter/setter, and expanded the `toString()` method to include richer metadata for debugging. [[1]](diffhunk://#diff-e0d1a8f61f3775fe9b4eb5e0f7855ef42e32d3c907795a43d70dce7430d45362R25) [[2]](diffhunk://#diff-e0d1a8f61f3775fe9b4eb5e0f7855ef42e32d3c907795a43d70dce7430d45362R60-R67) [[3]](diffhunk://#diff-e0d1a8f61f3775fe9b4eb5e0f7855ef42e32d3c907795a43d70dce7430d45362L161-R179)
* Introduced new domain records: `GoogleBooksResponse`, `GoogleBookItems`, `VolumeInfo`, and `BookMetaData` to represent structured book data from the API. [[1]](diffhunk://#diff-db0cf7e67a1df9e8106a0ac3b547fe086e782d2165d0ec508215d896c439bcaaR1-R6) [[2]](diffhunk://#diff-fafe35b89d44bf464afc6fb2df72fc97c6e4490cb87efc543715280fb30b3de5R1-R4) [[3]](diffhunk://#diff-7b65c9b162ef2b0794aa37f08d09c6e138df581f1c2a76091be788e679761251R1-R14) [[4]](diffhunk://#diff-7ffd14970d930343fcbd5b76166377a700489d4e886e969a34b19cf4c4cebe22R1-R5)

**Service Layer Improvements:**
* Implemented `BookEnrichmentService` to create enriched `Book` objects from Google Books API responses, including parsing author names and logging enriched data.

**Factory Pattern Extension:**
* Extended `AuthorFactory` with a method to create domain `Author` objects, maintaining separation from persistence logic.

**API Response Handling:**
* `BookInfoService.lookupBook()` now returns a typed `GoogleBooksResponse` using automatic JSON mapping, replacing raw string responses for safer and more maintainable code. [[1]](diffhunk://#diff-8efe5ba1963ebe0bb7f463481f1823a8cf103dc736eab13f165ecdbf8bab4d7fR3) [[2]](diffhunk://#diff-8efe5ba1963ebe0bb7f463481f1823a8cf103dc736eab13f165ecdbf8bab4d7fL16-R22)

([docs/the-devlogs/devlog-2025-12-01-book-enrichment.mdR1-R77](diffhunk://#diff-ae3ffff3b806ba8a1c2adabb25b8ab82c8242ae1797e3ea4c41ac717481c12b0R1-R77))- Replace String response with typed GoogleBooksResponse deserialization
- Wire BookEnrichmentService into lookup endpoint reactive chain
- Add publishedDate field to Book domain model
- Extend AuthorFactory with domain object creation method
- Expand Book.toString() for improved debugging

The /lookup/{isbn} endpoint now returns structured book metadata and triggers automatic enrichment when ISBNs are scanned.