### PR TITLE
feat(cli): implement multi-book scanning loop

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/book/BookCommandLine.java
+++ b/src/main/java/com/penrose/bibby/cli/book/BookCommandLine.java
@@ -148,6 +148,8 @@ public class BookCommandLine extends AbstractShellComponent {
 
         if(multi.equalsIgnoreCase("multi")){
             System.out.println("Scanning multiple books...");
+            List<String> scans = cliPrompt.promptMultiScan();
+            System.out.println(scans.size() + " books were added to the library.");
         }
 
         if(multi.equalsIgnoreCase("single")) {

--- a/src/main/java/com/penrose/bibby/cli/prompt/application/CliPromptService.java
+++ b/src/main/java/com/penrose/bibby/cli/prompt/application/CliPromptService.java
@@ -7,6 +7,7 @@ import com.penrose.bibby.library.shelf.application.ShelfService;
 import org.springframework.shell.component.flow.ComponentFlow;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import java.util.Map;
 public class CliPromptService {
     private final ComponentFlow.Builder componentFlowBuilder;
     private final ShelfService shelfService;
+    List<String> scans = new ArrayList<>();
 
     public CliPromptService(ComponentFlow.Builder componentFlowBuilder, ComponentFlow.Builder componentFlowBuilder1, BookcaseService bookcaseService, ShelfService shelfService) {
 
@@ -42,6 +44,22 @@ public class CliPromptService {
 
         ComponentFlow.ComponentFlowResult result = flow.run();
         return result.getContext().get("confirmation",String.class).equalsIgnoreCase("Yes");
+    }
+
+    public List<String> promptMultiScan(){
+        ComponentFlow flow = componentFlowBuilder.clone()
+                .withStringInput("multiScan")
+                .name("multi scan >:_")
+                .and().build();
+
+        ComponentFlow.ComponentFlowResult result = flow.run();
+        String scan = result.getContext().get("multiScan",String.class);
+
+        if(!scan.equalsIgnoreCase("done")){
+            scans.add(scan);
+            promptMultiScan();
+        }
+        return scans;
     }
 
     public Author promptForAuthor(){


### PR DESCRIPTION
This pull request adds support for scanning multiple books in the CLI and improves the user experience for batch additions. The changes introduce a new method to prompt for multiple book scans, update the CLI command to handle multi-scan mode, and refactor the prompt service to manage multiple scans.

**Multi-book scanning feature:**

* Added a new `promptMultiScan` method to `CliPromptService` that recursively prompts the user to enter book scans until "done" is entered, storing results in a list.
* Updated `BookCommandLine.scanBook` to use `promptMultiScan` when multi-scan mode is selected, and display the number of books added to the library.

**Refactoring and setup:**

* Introduced an `ArrayList` field `scans` in `CliPromptService` to store scanned book entries during a multi-scan session.
* Added missing import for `ArrayList` in `CliPromptService`.- Add promptMultiScan() to CliPromptService with recursive ISBN collection
- Loop prompts until user enters 'done'
- Wire multi-scan into BookCommandLine, display count on completion