### PR TITLE
chore(cli): simplify search menu to implemented options only

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/book/BookCommandLine.java
+++ b/src/main/java/com/penrose/bibby/cli/book/BookCommandLine.java
@@ -269,7 +269,7 @@ public class BookCommandLine extends AbstractShellComponent {
     }
 
     public void searchByTitle() throws InterruptedException {
-        System.out.println("\n");
+        System.out.println("\n\u001B[95mSearch by Title");
         String title = cliPrompt.promptForBookTitle();
         System.out.println("\u001B[36m</>\u001B[0m:Hold on, I’m diving into the stacks — Let’s see if I can find " + title);
         System.out.print("\u001B[36m</>\u001B[0m:");

--- a/src/main/java/com/penrose/bibby/cli/prompt/application/CliPromptService.java
+++ b/src/main/java/com/penrose/bibby/cli/prompt/application/CliPromptService.java
@@ -153,20 +153,22 @@ public class CliPromptService {
     private Map<String, String> buildSearchOptions() {
         // LinkedHashMap keeps insertion order so the menu shows in the order you add them
         Map<String, String> options = new LinkedHashMap<>();
-        options.put("""
-                        Show all books       (View the complete library)""", "all");
+//        options.put("""
+//                        Show all books       (View the complete library)""", "all");
         options.put("""
                         ISBN                 (Search by ISBN)""", "isbn");
         options.put("""
-                        Title or keyword     (Search by words in the title)""", "title");
+                        Title                (Search by the title)""", "title");
+//        options.put("""
+//                        keyword     (Search by words in the title)""", "title");
         options.put("""
                         Author               (Find books by author name)""", "author");
-        options.put("""
-                        Genre                (Filter books by literary category)""", "genre");
-        options.put("""
-                        Shelf/Location       (Locate books by physical shelf ID)""", "shelf");
-        options.put("""
-                        Status               (Show available or checked-out books)""", "status");
+//        options.put("""
+//                        Genre                (Filter books by literary category)""", "genre");
+//        options.put("""
+//                        Shelf/Location       (Locate books by physical shelf ID)""", "shelf");
+//        options.put("""
+//                        Status               (Show available or checked-out books)""", "status");
         return options;
     }
 


### PR DESCRIPTION
This pull request updates the book search command-line interface to simplify the search options and improve the user experience for searching by title. The main changes focus on streamlining the search menu and enhancing the visual feedback for users.

**User experience improvements:**

* Added colored output for the "Search by Title" prompt in `searchByTitle()` to make it more visually distinct and user-friendly.

**Search menu simplification:**

* Removed several search options from the CLI prompt service, including "Show all books", "Genre", "Shelf/Location", and "Status", leaving only ISBN, Title, and Author as available options.
* Updated the "Title or keyword" search option to just "Title" for clarity, and commented out the previous keyword option.- Comment out unimplemented search options (all, genre, shelf, status)

- Reduce menu to working options: ISBN, Title, Author

- Add Search by Title header for consistency

- Rename Title or keyword to just Title

<img width="1227" height="356" alt="Screenshot From 2025-12-04 15-10-28" src="https://github.com/user-attachments/assets/e4765c15-16b5-4aa2-8fa4-f725d953fe84" />
