### PR TITLE
updated readme for subdomains

### DIFF
--- a/src/main/java/com/penrose/bibby/library/catalog/README.md
+++ b/src/main/java/com/penrose/bibby/library/catalog/README.md
@@ -1,0 +1,123 @@
+# Catalog Subdomain
+
+## Purpose
+
+The **Catalog** subdomain exists to define and manage **what a book is** in Bibby: its **identity** and **bibliographic metadata** (title, authors, ISBN, edition, etc.). Catalog is the source of truth for book/author meaning in the **Personal Book Library Management** domain.
+
+Catalog answers questions like: “What book is this?” and “What metadata do we know about it?”
+
+------
+
+## In Scope
+
+- Book identity (e.g., `BookId`, `Isbn`)
+- Bibliographic metadata (title, subtitle, authors, edition, publisher, publication date, etc.)
+- Author identity and naming
+- ISBN lookup / metadata enrichment (e.g., Google Books integration) **as an outbound adapter**
+- Validations around bibliographic concepts (ISBN format, required fields, normalization)
+
+------
+
+## Out of Scope
+
+- Physical location and capacity (owned by **Storage/Placement**)
+- User-defined categorization like tags and booklists (owned by **Organization**)
+- Search/ranking/query UX (owned by **Discovery**)
+- Persistence schemas as “truth” (JPA entities are implementation details)
+- CLI/UI concerns (handled in adapters)
+
+------
+
+## Ubiquitous Language
+
+- **Book**: a bibliographic item in the user’s library (identity + metadata)
+- **ISBN**: an industry identifier for an edition of a book (validated/normalized)
+- **Title**: the human-readable name of a book
+- **Author**: a person or entity credited with creating the work
+- **Metadata**: descriptive information about a book (not placement, not categorization)
+- **Enrichment**: augmenting metadata from an external source using an identifier (e.g., ISBN)
+
+------
+
+## Key Rules / Invariants
+
+- A **Book** must have a stable identity (`BookId`).
+- If `Isbn` is present, it must be **valid and normalized** (format rules enforced in one place).
+- Author names should be normalized consistently (e.g., trimming, spacing rules).
+- Catalog defines what fields are considered canonical metadata vs optional enrichment.
+- Other subdomains must not redefine bibliographic meaning (they may *reference* it).
+
+------
+
+## Public API / Contracts
+
+Catalog should expose a minimal set of contracts for other subdomains/adapters, such as:
+
+- `BookSummary`
+  (for lists/search results; stable fields only)
+    - `bookId`
+    - `title`
+    - `primaryAuthor` (or list of authors)
+    - `isbn` (optional)
+- `BookDetails`
+  (for detailed views)
+    - `bookId`, `title`, `subtitle`, `authors`, `isbn`, `publisher`, `publishedDate`, …
+- `CatalogFacade` (or ports/use cases)
+    - `registerBook(...)`
+    - `getBookSummary(BookId)`
+    - `getBookDetails(BookId)`
+    - `findByIsbn(Isbn)` (optional)
+    - `enrichMetadataByIsbn(Isbn)` (optional)
+
+**Rule:** Other modules should depend on **contracts**, not Catalog’s internal domain objects.
+
+------
+
+## Dependencies
+
+Catalog may have outbound integrations (e.g., Google Books) behind ports such as:
+
+- `BookMetadataLookupPort`
+
+Infrastructure adapters implement those ports (WebClient, HTTP DTOs, etc.).
+
+Catalog should NOT depend on:
+
+- Storage/Placement internals
+- Organization internals
+- Discovery internals
+- shared JPA entities across modules
+
+------
+
+## Suggested Package Layout (inside `catalog/`)
+
+- `contracts/` — public DTOs/views exposed to other modules/adapters
+- `application/` — use cases (register, update metadata, lookup by ISBN)
+- `domain/` — entities/value objects/invariants (Book, Author, Isbn, BookTitle, etc.)
+- `infrastructure/` — persistence + outbound adapters (JPA, WebClient, external payload DTOs)
+
+(Exact naming can match your existing structure; the important part is the boundary.)
+
+------
+
+## Example Flows
+
+- **Add book by ISBN**
+    1. Validate/normalize ISBN (`Isbn`)
+    2. Lookup metadata via `BookMetadataLookupPort`
+    3. Create `Book` with canonical fields + optional enriched metadata
+    4. Persist through repository
+    5. Return `BookDetails` or `BookSummary` contract
+- **Get book summary for display**
+    - `CatalogFacade.getBookSummary(bookId)` → `BookSummary`
+
+------
+
+## Notes
+
+Catalog is about **bibliographic truth** for the personal library. It should remain stable as other subdomains evolve. When in doubt, ask:
+
+> “Is this about what the book *is*, or about how the book is *used/organized/placed*?”
+
+If it’s not “what the book is,” it probably doesn’t belong here.

--- a/src/main/java/com/penrose/bibby/library/discovery/README.md
+++ b/src/main/java/com/penrose/bibby/library/discovery/README.md
@@ -1,0 +1,123 @@
+Absolutely — here’s a clean, “won’t rot” `README.md` you can drop into:
+
+`com/penrose/bibby/library/discovery/README.md`
+
+---
+
+# Discovery Subdomain
+
+## Purpose
+
+The **Discovery** subdomain exists to help users **find books quickly** using **search, filtering, and sorting**, without leaking persistence details or forcing other subdomains to share internal models.
+
+Discovery is a **read-focused** capability: it answers questions like “show me books that match X.”
+
+---
+
+## In Scope
+
+* Text search (title, author name, ISBN, tags, booklists)
+* Filters (e.g., by author, tag, booklist, shelf/bookcase)
+* Sorting (title, author, recently added, etc.)
+* Query models / view models optimized for read UX (CLI/UI)
+* Search result shaping (summary vs detail views)
+
+---
+
+## Out of Scope
+
+* Book identity and metadata rules (owned by **Catalog**)
+* Physical placement rules/capacity (owned by **Storage/Placement**)
+* Tag and booklist invariants (owned by **Organization**)
+* Persistence schemas (JPA entities) as domain truth
+* Write workflows (creating/editing books, tagging, placing)
+
+Discovery **consumes** read-friendly projections from other subdomains; it does not own the truth of those concepts.
+
+---
+
+## Ubiquitous Language
+
+* **Query**: a user’s search intent (text + filters + sort)
+* **Filter**: a constraint applied to results (e.g., tag = “FP”)
+* **Facet**: a filter dimension users can select (tags, authors, shelves)
+* **Result**: a matched book entry returned by discovery
+* **View / Projection**: a read-optimized representation for display (not a domain object)
+* **Index** (optional future): a structure that accelerates search (may be DB or external)
+
+---
+
+## Key Rules / Invariants
+
+* Discovery results must be **consistent in meaning** with the source subdomain contracts.
+* Discovery must not depend directly on other subdomains’ **domain** types (Entities/Value Objects).
+* Discovery may cache/denormalize **read data**, but must treat it as **derived**, not authoritative.
+* A “search result” is a **view**, not a domain model: it can contain merged fields across subdomains.
+* Search must be deterministic for the same inputs (unless explicitly using ranking).
+
+---
+
+## Public API / Contracts
+
+Discovery should expose a small, stable contract such as:
+
+* `SearchBooksQuery` (input)
+
+    * `text`
+    * `filters` (tags, booklists, author, location)
+    * `sort`
+    * `page` / `limit`
+* `BookSearchResultView` (output)
+
+    * `bookId`
+    * `displayTitle`
+    * `primaryAuthor`
+    * `isbn` (optional)
+    * `locationSummary` (optional)
+    * `tagNames` (optional)
+    * `booklists` (optional)
+
+**Recommended entrypoint**
+
+* `DiscoveryFacade` (or `SearchBooksUseCase` port)
+
+    * `search(SearchBooksQuery) -> Page<BookSearchResultView>`
+
+Adapters (CLI, REST) call Discovery through this contract.
+
+---
+
+## Dependencies
+
+Discovery is allowed to depend on **contracts** from:
+
+* `library.catalog.contracts` (book/author summaries)
+* `library.organization.contracts` (tag/booklist summaries)
+* `library.storage.contracts` (location summaries)
+
+Discovery should NOT depend on:
+
+* JPA entities from any module
+* internal domain objects from any module
+
+---
+
+## Example Queries
+
+* “functional programming” (text search)
+* filter: `tag = "Java"`
+* filter: `booklist = "System Design"`
+* filter: `shelf = "Shelf-3"`
+* sort: `recentlyAdded`
+
+---
+
+## Implementation Notes (Guidance)
+
+* Start with a simple DB-backed search (SQL/JPQL) using read DTOs/views.
+* Keep query logic in the **application** layer; keep storage-specific concerns in **infrastructure**.
+* If discovery grows, consider a dedicated read model or index (still behind the same contracts).
+
+---
+
+If you want, paste your intended discovery commands (CLI: `book search ...`?) and I’ll tailor the **Ubiquitous Language** + **contracts** to match your actual query shapes and naming style.


### PR DESCRIPTION
This pull request adds comprehensive documentation for the Catalog and Discovery subdomains by introducing new `README.md` files. These documents clarify each subdomain’s responsibilities, boundaries, key rules, and integration contracts, providing clear guidance for future development and cross-team collaboration.

**Domain Documentation Additions:**

* Added a detailed `README.md` to `catalog/` outlining the Catalog subdomain’s purpose, scope, key invariants, public API contracts (such as `BookSummary`, `BookDetails`, and `CatalogFacade`), and recommended package structure. This documentation emphasizes Catalog as the source of bibliographic truth and defines its boundaries with other subdomains.
* Added a comprehensive `README.md` to `discovery/` describing the Discovery subdomain’s focus on search, filtering, and read-optimized views. The documentation specifies in-scope/out-of-scope concerns, ubiquitous language, key invariants, public API contracts (such as `SearchBooksQuery`, `BookSearchResultView`, and `DiscoveryFacade`), and integration points with other subdomains.