### PR TITLE
docs(cataloging): add initial domain documentation placeholders

### DIFF
--- a/src/main/java/com/penrose/bibby/library/cataloging/docs/adr.md
+++ b/src/main/java/com/penrose/bibby/library/cataloging/docs/adr.md
@@ -1,0 +1,1 @@
+decisions worth recording

--- a/src/main/java/com/penrose/bibby/library/cataloging/docs/contracts.md
+++ b/src/main/java/com/penrose/bibby/library/cataloging/docs/contracts.md
@@ -1,0 +1,1 @@
+contracts.md) — public interfaces: ports, facades, events

--- a/src/main/java/com/penrose/bibby/library/cataloging/docs/invariants.md
+++ b/src/main/java/com/penrose/bibby/library/cataloging/docs/invariants.md
@@ -1,0 +1,1 @@
+invariants.md — “must always be true” rules (testable statements)

--- a/src/main/java/com/penrose/bibby/library/cataloging/docs/ubiquitous-language.md
+++ b/src/main/java/com/penrose/bibby/library/cataloging/docs/ubiquitous-language.md
@@ -1,0 +1,1 @@
+ubiquitous-language.md — key terms + meanings (20-ish max)


### PR DESCRIPTION
Add four new docs under src/main/java/com/penrose/bibby/library/cataloging/docs to capture key domain information:

adr.md: decisions worth recording
contracts.md: public interfaces — ports, facades, events invariants.md: "must always be true" rules (testable statements) ubiquitous-language.md: key terms and meanings (≈20) These placeholders provide a starting point for architecture decision records, interface contracts, domain invariants, and the ubiquitous language for the cataloging bounded context.