### PR TITLE
refactor(shelf): use ShelfId and rename outbound repo impl to adapter

### DIFF
--- a/docs/systems/architecture/modules/author-module/author-facade-impl/class-diagram-author-facade.md
+++ b/docs/systems/architecture/modules/author-module/author-facade-impl/class-diagram-author-facade.md
@@ -8,7 +8,7 @@ classDiagram
 
     direction BT
 
-%% Facade as inbound port
+%% Facade as inbound adapter
     class AuthorFacade {
 <<interface>>   
         + Set~AuthorDTO~      findByBookId(Long bookId)

--- a/docs/systems/architecture/modules/author-module/author-facade-impl/sequence-diagram-findOrCreateAuthor.md
+++ b/docs/systems/architecture/modules/author-module/author-facade-impl/sequence-diagram-findOrCreateAuthor.md
@@ -7,7 +7,7 @@ sequenceDiagram
     participant AuthorService as Service (Use Case Logic)
     participant AuthorMapper as Mapper (Domain → DTO)
 
-%% Caller invokes the inbound port
+%% Caller invokes the inbound adapter
     Caller->>AuthorFacadeImpl: findOrCreateAuthor(firstName, lastName)
 
 %% Facade delegates to Application layer

--- a/docs/the-devlogs/devlog-2025-12-07-Ports-and-Adapters-Restructuring.md
+++ b/docs/the-devlogs/devlog-2025-12-07-Ports-and-Adapters-Restructuring.md
@@ -236,7 +236,7 @@ public class BookService implements BookFacade {
 package com.penrose.bibby.library.book.core.application;
 
 import com.penrose.bibby.library.cataloging.book.core.domain.AuthorRef;                           // ✓ Book's own type
-import com.penrose.bibby.library.cataloging.book.contracts.ports.outbound.AuthorAccessPort;  // ✓ Book's own port
+import com.penrose.bibby.library.cataloging.book.contracts.ports.outbound.AuthorAccessPort;  // ✓ Book's own adapter
 
 public class BookService implements BookFacade {
     private final AuthorAccessPort authorAccessPort;

--- a/docs/the-devlogs/devlog-2025-12-10-Fixing-Book-Author-Persistence-Enforce-Facade-Boundaries.md
+++ b/docs/the-devlogs/devlog-2025-12-10-Fixing-Book-Author-Persistence-Enforce-Facade-Boundaries.md
@@ -118,7 +118,7 @@ public BookController(BookService bookService, BookFacade bookFacade, ...) {
 
 @PostMapping("api/v1/books")
 public ResponseEntity<String> addBook(@RequestBody BookRequestDTO requestDTO) {
-    bookFacade.createNewBook(requestDTO);  // Through the port
+    bookFacade.createNewBook(requestDTO);  // Through the adapter
 }
 ```
 
@@ -407,7 +407,7 @@ public void registerBook(Book book) {
 ```java
 @PostMapping("api/v1/books")
 public ResponseEntity<String> addBook(@RequestBody BookRequestDTO requestDTO) {
-    bookService.createNewBook(requestDTO);  // Bypasses port
+    bookService.createNewBook(requestDTO);  // Bypasses adapter
     return ResponseEntity.ok("Book Added Successfully: " + requestDTO.title());
 }
 ```
@@ -416,7 +416,7 @@ public ResponseEntity<String> addBook(@RequestBody BookRequestDTO requestDTO) {
 ```java
 @PostMapping("api/v1/books")
 public ResponseEntity<String> addBook(@RequestBody BookRequestDTO requestDTO) {
-    bookFacade.createNewBook(requestDTO);  // Through inbound port
+    bookFacade.createNewBook(requestDTO);  // Through inbound adapter
     return ResponseEntity.ok("Book Added Successfully: " + requestDTO.title());
 }
 ```

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/Shelf.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/Shelf.java
@@ -1,9 +1,11 @@
 package com.penrose.bibby.library.stacks.shelf.core.domain;
 
+import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
+
 import java.util.List;
 
 public class Shelf {
-    private Long id;
+    private ShelfId shelfId;
     private String shelfLabel;
     private String shelfDescription;
     private int shelfPosition;
@@ -66,10 +68,7 @@ public class Shelf {
     }
 
     public Long getId() {
-        return id;
-    }
-    public void setId(Long id) {
-        this.id = id;
+        return this.shelfId.shelfId();
     }
 
     public String getShelfDescription() {
@@ -87,7 +86,7 @@ public class Shelf {
     @Override
     public String toString() {
         return "Shelf{" +
-                "id=" + id +
+                "shelf=" + shelfId +
                 ", shelfLabel='" + shelfLabel + '\'' +
                 ", shelfDescription='" + shelfDescription + '\'' +
                 ", shelfPosition=" + shelfPosition +

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/ShelfDomainRepository.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/ShelfDomainRepository.java
@@ -1,8 +1,10 @@
 package com.penrose.bibby.library.stacks.shelf.core.domain;
 
+import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
+
 public interface ShelfDomainRepository {
 
-    Shelf getById(Long id);
+    Shelf getById(ShelfId id);
 
     void save(Shelf shelf);
 

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/valueobject/ShelfId.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/valueobject/ShelfId.java
@@ -1,0 +1,4 @@
+package com.penrose.bibby.library.stacks.shelf.core.domain.valueobject;
+
+public record ShelfId(Long shelfId) {
+}

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/adapter/outbound/ShelfDomainRepositoryImpl.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/adapter/outbound/ShelfDomainRepositoryImpl.java
@@ -1,7 +1,10 @@
-package com.penrose.bibby.library.stacks.shelf.core.domain;
+package com.penrose.bibby.library.stacks.shelf.infrastructure.adapter.outbound;
 
 import com.penrose.bibby.library.cataloging.book.core.domain.Book;
 import com.penrose.bibby.library.cataloging.book.core.domain.BookDomainRepository;
+import com.penrose.bibby.library.stacks.shelf.core.domain.Shelf;
+import com.penrose.bibby.library.stacks.shelf.core.domain.ShelfDomainRepository;
+import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.entity.ShelfEntity;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.repository.ShelfJpaRepository;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.mapping.ShelfMapper;
@@ -26,9 +29,9 @@ public class ShelfDomainRepositoryImpl implements ShelfDomainRepository {
     }
 
     @Override
-    public Shelf getById(Long id) {
-        ShelfEntity entity = jpaRepository.findById(id).orElse(null);
-        List<Book> books = bookDomainRepository.getBooksByShelfId(id);
+    public Shelf getById(ShelfId id) {
+        ShelfEntity entity = jpaRepository.findById(id.shelfId()).orElse(null);
+        List<Book> books = bookDomainRepository.getBooksByShelfId(id.shelfId());
         List<Long> bookIds = new ArrayList<>();
         for(Book book : books){
             bookIds.add(book.getBookId().getId());


### PR DESCRIPTION
This pull request introduces a refactor to the Shelf domain model by introducing a `ShelfId` value object and updating all related interfaces, implementations, and usages to use `ShelfId` instead of a raw `Long` for shelf identification. Additionally, it cleans up terminology in documentation to consistently use "adapter" instead of "port" where appropriate, and moves the `ShelfDomainRepositoryImpl` to a more appropriate infrastructure package.

**Shelf domain refactor:**

* Introduced a new value object `ShelfId` to encapsulate shelf identifiers, replacing usages of `Long` for shelf IDs in the `Shelf` entity and related repository interfaces (`Shelf`, `ShelfDomainRepository`, and their implementations). [[1]](diffhunk://#diff-733f7579affa8d20f88a2b66b8047af780afdc03c1120fafcb28a457bc445436R3-R8) [[2]](diffhunk://#diff-733f7579affa8d20f88a2b66b8047af780afdc03c1120fafcb28a457bc445436L69-R71) [[3]](diffhunk://#diff-733f7579affa8d20f88a2b66b8047af780afdc03c1120fafcb28a457bc445436L90-R89) [[4]](diffhunk://#diff-325be5080d11b2d2ebc3797f01d395ffafb918e11aecbab1a4ba3d38bf1dcaa9R3-R7) [[5]](diffhunk://#diff-167254b8dc221816f95b77c8cbaf2fc90ba963ee15faeca753e5902fd67792e5R1-R4)
* Updated the `ShelfDomainRepositoryImpl` implementation to use `ShelfId` and moved it from the domain package to the infrastructure adapter outbound package for better separation of concerns. [[1]](diffhunk://#diff-d0609bdf36f5c07f8ae9c75e50edf1ec3046b840953c6537ccc888f7967a605fL1-R7) [[2]](diffhunk://#diff-d0609bdf36f5c07f8ae9c75e50edf1ec3046b840953c6537ccc888f7967a605fL29-R34)

**Documentation terminology updates:**

* Standardized terminology in architecture and devlog documentation by replacing references to "port" with "adapter" for facades and service calls, improving clarity and consistency with the ports and adapters architecture. [[1]](diffhunk://#diff-1ed99597d0374655b09e9d87fa1a0ba55a0583177670908f0fe5b3f933cf190aL11-R11) [[2]](diffhunk://#diff-2591940ac2172edf536722a46c376b1c7754440f97b9a552fff4342fad802a0eL10-R10) [[3]](diffhunk://#diff-83e2f192168e049bf5380e78193ddc46c87bdd02c5fdcf7d82034f6268625920L239-R239) [[4]](diffhunk://#diff-da998b21760632050a44ee803dfba534f537a0e21e576db2e53dc14fbabceca0L121-R121) [[5]](diffhunk://#diff-da998b21760632050a44ee803dfba534f537a0e21e576db2e53dc14fbabceca0L410-R410) [[6]](diffhunk://#diff-da998b21760632050a44ee803dfba534f537a0e21e576db2e53dc14fbabceca0L419-R419)- Replace Shelf Long id with ShelfId value object and update repository contract

- Update JPA-backed repository implementation to accept ShelfId and unwrap for persistence lookups

- Rename infrastructure package from port.outbound to adapter.outbound

- Fix docs wording: facade described as inbound adapter (not inbound port)