### PR TITLE
added shelfId to constructor

### DIFF
--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
@@ -6,6 +6,7 @@ import com.penrose.bibby.library.cataloging.book.infrastructure.repository.BookJ
 import com.penrose.bibby.library.stacks.shelf.contracts.dtos.ShelfDTO;
 import com.penrose.bibby.library.stacks.shelf.contracts.ports.inbound.ShelfFacade;
 import com.penrose.bibby.library.stacks.shelf.core.domain.Shelf;
+import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.entity.ShelfEntity;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.mapping.ShelfMapper;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.repository.ShelfJpaRepository;
@@ -76,7 +77,8 @@ public class ShelfService implements ShelfFacade {
         return new Shelf(
                 shelfDTO.shelfLabel(),
                 shelfDTO.shelfPosition(),
-                shelfDTO.bookCapacity()
+                shelfDTO.bookCapacity(),
+                new ShelfId(shelfDTO.shelfId())
         );
     }
 

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/Shelf.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/Shelf.java
@@ -13,10 +13,11 @@ public class Shelf {
     private List<Long> bookIds;
 
 
-    public Shelf(String shelfLabel, int shelfPosition, int bookCapacity) {
+    public Shelf(String shelfLabel, int shelfPosition, int bookCapacity, ShelfId shelfId) {
         this.shelfLabel = shelfLabel;
         this.shelfPosition = shelfPosition;
         this.bookCapacity = bookCapacity;
+        this.shelfId = shelfId;
     }
 
     public boolean isFull(){


### PR DESCRIPTION
This pull request updates the `Shelf` domain model to include a `ShelfId` value object, ensuring that shelf identifiers are explicitly managed within the domain layer. The changes also update the `ShelfService` to map the `shelfId` from the DTO into the domain model. This improves the clarity and robustness of the shelf identity handling in the application.

**Domain model enhancements:**

* Updated the `Shelf` class constructor to accept and assign a `ShelfId` value object, making shelf identity explicit in the domain model.

**Service and mapping updates:**

* Modified the `ShelfService.mapToDomain` method to construct a `ShelfId` from the DTO's `shelfId` and pass it to the `Shelf` constructor, ensuring the domain model receives the correct identifier.
* Added import of `ShelfId` in `ShelfService` to support the updated mapping logic.