### PR TITLE
feat(shelf): add BrowseShelfUseCase and BriefBibliographicRecord proj…

### DIFF
--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/BrowseShelfUseCase.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/BrowseShelfUseCase.java
@@ -1,0 +1,15 @@
+package com.penrose.bibby.library.stacks.shelf.core.application;
+
+import com.penrose.bibby.library.stacks.shelf.core.domain.BriefBibliographicRecord;
+
+public class BrowseShelfUseCase {
+
+    BriefBibliographicRecord briefBibliographicRecord;
+
+    public BrowseShelfUseCase(){
+
+    }
+
+
+
+}

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/BriefBibliographicRecord.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/BriefBibliographicRecord.java
@@ -1,0 +1,13 @@
+package com.penrose.bibby.library.stacks.shelf.core.domain;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * A lightweight, read-only bibliographic view of a book used for shelf browsing and display.
+ * <p>
+ * Represents a “brief bib record” (not the full Book domain model) and contains only the core
+ * descriptive metadata needed to identify and present a resource in the Shelf context.
+ */
+@Component
+public class BriefBibliographicRecord {
+}


### PR DESCRIPTION
This pull request introduces the initial scaffolding for shelf browsing functionality by adding two new classes: `BrowseShelfUseCase` and `BriefBibliographicRecord`. These classes lay the groundwork for future development related to browsing shelves and displaying brief bibliographic information.

**New shelf browsing use case:**

* Added the `BrowseShelfUseCase` class in the `core.application` package as an entry point for shelf browsing logic. This class currently contains a placeholder for a `BriefBibliographicRecord` and an empty constructor.

**Brief bibliographic record model:**

* Introduced the `BriefBibliographicRecord` class in the `core.domain` package, annotated as a Spring `@Component`. This class is intended as a lightweight, read-only representation of a book's core metadata for shelf display purposes.…ection