### PR TITLE
feat(shelf): define BriefBibliographicRecord and docs

### DIFF
--- a/src/main/java/com/penrose/bibby/library/stacks/docs/diagrams/ClassDiagram-BriefBibliographicRecord.md
+++ b/src/main/java/com/penrose/bibby/library/stacks/docs/diagrams/ClassDiagram-BriefBibliographicRecord.md
@@ -1,0 +1,15 @@
+```mermaid
+classDiagram
+  class BriefBibliographicRecord {
+    <<record>>
+    +Long bookId
+    +String title
+    +List~String~ authors
+    +int edition
+    +String publisher
+    +int publicationYear
+    +String isbn
+    +String summary
+  }
+
+```

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/BriefBibliographicRecord.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/BriefBibliographicRecord.java
@@ -1,6 +1,6 @@
 package com.penrose.bibby.library.stacks.shelf.core.domain;
 
-import org.springframework.stereotype.Component;
+import java.util.List;
 
 /**
  * A lightweight, read-only bibliographic view of a book used for shelf browsing and display.
@@ -8,6 +8,15 @@ import org.springframework.stereotype.Component;
  * Represents a “brief bib record” (not the full Book domain model) and contains only the core
  * descriptive metadata needed to identify and present a resource in the Shelf context.
  */
-@Component
-public class BriefBibliographicRecord {
+public record BriefBibliographicRecord(
+        Long bookId,
+        String title,
+        List<String> authors,
+        int edition,
+        String publisher,
+        String publicationYear,
+        String isbn,
+        String summary
+    ){
+
 }


### PR DESCRIPTION
This pull request refactors the `BriefBibliographicRecord` class in the shelf domain to use a Java record for improved immutability and simplicity, and adds a corresponding class diagram in Mermaid format for documentation.

Domain model refactor:

* Converted `BriefBibliographicRecord` from a mutable class to a Java record, making it immutable and simplifying its structure. This also removes the unnecessary `@Component` annotation and updates the type of `authors` to `List<String>`. (`BriefBibliographicRecord.java`)

Documentation updates:

* Added a Mermaid class diagram for `BriefBibliographicRecord` to visually document its structure and fields. (`ClassDiagram-BriefBibliographicRecord.md`)Introduce a lightweight, read-only bibliographic view for shelf browsing as a Java 'record' and document it with a class diagram.

Domain:
- BriefBibliographicRecord (record) with fields: Long bookId, String title, List<String> authors, int edition, String publisher, String publicationYear, String isbn, String summary
- Purpose: provide minimal descriptive metadata for shelf browsing/display; immutable and easy to map.

Docs:
- Add 'ClassDiagram-BriefBibliographicRecord.md' illustrating the brief bib record in the Shelf context.

Refs: used by BrowseShelfUseCase