### PR TITLE
KAN-10 Display Book Details Before Add Confirmation

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/commands/book/BookCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/commands/book/BookCommands.java
@@ -73,6 +73,14 @@ public class BookCommands extends AbstractShellComponent {
 
         log.debug("Authors verified/created for book.");
         log.info(bookMetaDataResponse.toString());
+        String bookcard = createBookCard(bookMetaDataResponse.title(),
+                bookMetaDataResponse.isbn(),
+                bookMetaDataResponse.authors().toString(),
+                bookMetaDataResponse.publisher(),
+                "PENDING / NOT SET",
+                "PENDING / NOT SET");
+        System.out.println(bookcard);
+
         if (cliPrompt.promptBookConfirmation()) bookFacade.createBookFromMetaData(bookMetaDataResponse, authorIds, isbn, null);
 
     }
@@ -282,7 +290,7 @@ public class BookCommands extends AbstractShellComponent {
 
 
 
-    public String createBookCard(String title, String isbn, String author, String bookcase, String shelf) {
+    public String createBookCard(String title, String isbn, String author, String publisher, String bookcase, String shelf) {
 
         // %-42s ensures the text is left-aligned and padded to 42 characters
         // The emojis take up extra visual space, so adjusted padding slightly
@@ -293,13 +301,14 @@ public class BookCommands extends AbstractShellComponent {
                 ├──────────────────────────────────────────────────────────────────────────────┤
                 │  \033[38;5;42mISBN\033[0m: %-31s                                       │
                 │  \033[38;5;42mAuthor\033[0m: %-31s                                     │
+                │  \033[38;5;42mPublisher\033[0m: %-31s                                     │
                 │                                                                              │
                 │  \033[38;5;42mBookcase\033[0m: %-35s                               │
                 │  \033[38;5;42mShelf\033[0m: %-35s                                  │
                 ╰──────────────────────────────────────────────────────────────────────────────╯
                 
                 
-        """.formatted(title, isbn, author, bookcase,shelf);
+        """.formatted(title, isbn, author, publisher, bookcase,shelf);
     }
 
 // Usage:
@@ -358,6 +367,7 @@ public class BookCommands extends AbstractShellComponent {
                         bookDTO.title(),
                         bookDTO.isbn(),
                         authors.toString(),
+                        bookDTO.publisher(),
                         bookcaseLocation,
                         shelfLocation
                 );
@@ -411,6 +421,7 @@ public class BookCommands extends AbstractShellComponent {
                     bookDTO.title(),
                     bookDTO.isbn(),
                     authorFacade.findByBookId(bookDTO.id()).toString(),
+                    bookDTO.publisher(),
                     "PENDING / NOT SET",
                     "PENDING / NOT SET"
 
@@ -424,6 +435,7 @@ public class BookCommands extends AbstractShellComponent {
                     bookDTO.title(),
                     bookDTO.isbn(),
                     authorFacade.findByBookId(bookDTO.id()).toString(),
+                    "PENDING / NOT SET",
                     bookcaseDTO.get().bookcaseLabel(),
                     shelfDTO.get().shelfLabel()
             );

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,10 +18,10 @@ spring.main.banner-mode=console
 #logging.level.org.springframework=OFF
 #logging.level.org.hibernate=OFF
 #logging.level.root=OFF
-
+#
 logging.level.root=INFO
 logging.level.org.springframework=INFO
-#logging.level.org.hibernate=INFO
+logging.level.org.hibernate=INFO
 
 spring.output.ansi.enabled=ALWAYS
 


### PR DESCRIPTION
This pull request enhances the display of book information in the command-line interface by updating the `createBookCard` method to include the publisher field and ensuring it is shown wherever book cards are printed. It also makes minor configuration changes to logging in the application properties.

**Book Card Display Improvements:**

* Added a `publisher` field to the `createBookCard` method signature and updated all usages to supply the publisher information, ensuring book cards now display the publisher alongside title, ISBN, author, bookcase, and shelf. [[1]](diffhunk://#diff-801e28f54686a3e42e8c04ea320befe7bce5927c2511c3d7977598f8cc3f4ab4L285-R293) [[2]](diffhunk://#diff-801e28f54686a3e42e8c04ea320befe7bce5927c2511c3d7977598f8cc3f4ab4R304-R311) [[3]](diffhunk://#diff-801e28f54686a3e42e8c04ea320befe7bce5927c2511c3d7977598f8cc3f4ab4R370) [[4]](diffhunk://#diff-801e28f54686a3e42e8c04ea320befe7bce5927c2511c3d7977598f8cc3f4ab4R424) [[5]](diffhunk://#diff-801e28f54686a3e42e8c04ea320befe7bce5927c2511c3d7977598f8cc3f4ab4R438) [[6]](diffhunk://#diff-801e28f54686a3e42e8c04ea320befe7bce5927c2511c3d7977598f8cc3f4ab4R76-R83)

**Configuration Updates:**

* Enabled INFO-level logging for Hibernate by uncommenting and setting `logging.level.org.hibernate=INFO` in `application.properties`.