### PR TITLE
feat(cli): prompt for bookcase/shelf after scan confirmation

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/commands/book/BookCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/commands/book/BookCommands.java
@@ -81,7 +81,11 @@ public class BookCommands extends AbstractShellComponent {
                 "PENDING / NOT SET");
         System.out.println(bookcard);
 
-        if (cliPrompt.promptBookConfirmation()) bookFacade.createBookFromMetaData(bookMetaDataResponse, authorIds, isbn, null);
+        if (cliPrompt.promptBookConfirmation()) {
+            Long bookcaseId = cliPrompt.promptForBookCase(bookCaseOptions());
+            Long shelfId = cliPrompt.promptForShelf(bookcaseId);
+            bookFacade.createBookFromMetaData(bookMetaDataResponse, authorIds, isbn, shelfId);
+        }
 
     }
 


### PR DESCRIPTION
This pull request improves the workflow for adding a new book by prompting the user to select a bookcase and shelf before creating the book. This ensures that each new book is assigned to a specific location in the system.

Enhancements to book creation workflow:

* Updated `scanBook` in `BookCommands.java` to prompt the user for a bookcase and shelf, and then pass the selected shelf ID to `createBookFromMetaData`, ensuring new books are assigned a location.After confirming add in `book new --scan`, prompt the user to select a Bookcase and Shelf, then persist the book with the selected shelfId instead of creating a locationless record.