### PR TITLE
docs(classification): add README for module overview

### DIFF
--- a/src/main/java/com/penrose/bibby/library/classification/README.md
+++ b/src/main/java/com/penrose/bibby/library/classification/README.md
@@ -1,0 +1,5 @@
+# Classification Module
+
+> **Logical organization of books** — how books are grouped, categorized, and tracked.
+
+While the **Stacks** module tracks *where* books physically live (bookcase → shelf), the **Classification** module tracks *how* books are conceptually organized.


### PR DESCRIPTION
This pull request adds introductory documentation for the `Classification` module, clarifying its purpose and how it differs from the `Stacks` module.

Documentation improvements:

* Added a new section to `src/main/java/com/penrose/bibby/library/classification/README.md` explaining the role of the `Classification` module and its distinction from the `Stacks` module.- Provide a conceptual explanation of the Classification module
- Clarify its distinction from the Stacks module