### PR TITLE
refactor(cli): extract BookPlacementCommands from BookCommands

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/command/book/BookCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/command/book/BookCommands.java
@@ -64,52 +64,7 @@ public class BookCommands extends AbstractShellComponent {
         this.bookcardRenderer = bookcardRenderer;
     }
 
-    // ───────────────────────────────────────────────────────────────────
-    //
-    //                        Book Create Commands
-    //
-    //
-    // ───────────────────────────────────────────────────────────────────
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-    @Command(command = "shelf", description = "Place a book on a shelf or move it to a new location.")
-    public void addToShelf(){
-        // What if the library has multiple copies of the same book title?
-        // For now, we will assume titles are unique
-        // todo(priority 2): prompt user to select from multiple copies if found
-        String title = cliPrompt.promptForBookTitle();
-        BookDTO bookDTO = bookFacade.findBookByTitle(title);
-        if(bookDTO == null){
-            System.out.println("Book Not Found In Library");
-        }else {
-            Long bookCaseId = cliPrompt.promptForBookCase(promptOptions.bookCaseOptions());
-            Long newShelfId = cliPrompt.promptForShelf(bookCaseId);
-
-            //Checks if shelf is full/capacity reached
-            Optional<ShelfDTO> shelfDTO = shelfFacade.findShelfById(newShelfId);
-//            Boolean isFull = shelfFacade.isFull(shelfDTO.get());
-            if(shelfDTO.get().bookCapacity() <= shelfDTO.get().bookIds().size()){
-                throw new IllegalStateException("Shelf is full");
-            }else{
-
-                bookFacade.updateTheBooksShelf(bookDTO, newShelfId);
-
-                System.out.println("Added Book To the Shelf!");
-            }
-        }
-    }
 
 
 //


### PR DESCRIPTION
This pull request refactors the logic for placing books on shelves by moving the `addToShelf` command from the `BookCommands` class to a new, dedicated `BookPlacementCommands` class. This change improves code organization and separation of concerns.

**Command refactoring and code organization:**

* Moved the `addToShelf` command (for placing or moving a book to a shelf) from `BookCommands` in `BookCommands.java` to a new `BookPlacementCommands` class in its own file, `BookPlacementCommands.java`. This helps separate book placement logic from other book-related commands and makes the codebase more modular. [[1]](diffhunk://#diff-148845a42d71ec750c542074dba65c1f92d2893218db893be6a006680aa5f3a7L67-L114) [[2]](diffhunk://#diff-84f12bd84aee85e24e63fcea0b69787ffb34af0dd937b355f6e0f1e58d694e2bR1-R64)

**New component creation:**

* Added the new `BookPlacementCommands` class, annotated as a `@ShellComponent`, to encapsulate book placement commands and their dependencies.- Move `addToShelf` logic to the newly created `BookPlacementCommands` class.
- Remove redundant `addToShelf` method and related imports from `BookCommands`.
- Improve separation of concerns by isolating book placement-related commands into a dedicated class.