### PR TITLE
Extract scan manual bookcreate

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/command/book/BookCreateCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/command/book/BookCreateCommands.java
@@ -1,15 +1,10 @@
 package com.penrose.bibby.cli.command.book;
 
 import com.penrose.bibby.cli.prompt.application.CliPromptService;
-import com.penrose.bibby.cli.prompt.domain.PromptOptions;
-import com.penrose.bibby.cli.ui.BookcardRenderer;
 import com.penrose.bibby.library.cataloging.author.contracts.AuthorDTO;
 import com.penrose.bibby.library.cataloging.author.contracts.ports.AuthorFacade;
-import com.penrose.bibby.library.cataloging.book.contracts.dtos.BookMetaDataResponse;
 import com.penrose.bibby.library.cataloging.book.contracts.dtos.BookRequestDTO;
 import com.penrose.bibby.library.cataloging.book.contracts.ports.inbound.BookFacade;
-import com.penrose.bibby.library.stacks.bookcase.contracts.ports.inbound.BookcaseFacade;
-import com.penrose.bibby.library.stacks.shelf.contracts.ports.inbound.ShelfFacade;
 import org.slf4j.Logger;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.standard.ShellComponent;
@@ -39,93 +34,15 @@ import java.util.List;
 public class BookCreateCommands {
     Logger log = org.slf4j.LoggerFactory.getLogger(BookCreateCommands.class);
     private final CliPromptService cliPrompt;
-    private final BookcardRenderer bookcardRenderer;
     private final BookFacade bookFacade;
-    private final BookcaseFacade bookcaseFacade;
-    private final ShelfFacade shelfFacade;
     private final AuthorFacade authorFacade;
-    private final PromptOptions promptOptions;
 
-    public BookCreateCommands(CliPromptService cliPrompt, BookcardRenderer bookcardRenderer, BookFacade bookFacade, BookcaseFacade bookcaseFacade, ShelfFacade shelfFacade, AuthorFacade authorFacade, PromptOptions promptOptions){
+    public BookCreateCommands(CliPromptService cliPrompt, BookFacade bookFacade, AuthorFacade authorFacade){
 
         this.cliPrompt = cliPrompt;
-        this.bookcardRenderer = bookcardRenderer;
         this.bookFacade = bookFacade;
-        this.bookcaseFacade = bookcaseFacade;
-        this.shelfFacade = shelfFacade;
         this.authorFacade = authorFacade;
-        this.promptOptions = promptOptions;
     }
-
-
-
-
-    /*
-    ============================
-        CLI Command Endpoints (Spring Shell entry points)
-    ============================
-     */
-
-    /**
-     * Scans a book's ISBN barcode to retrieve metadata and adds the book to the library system.
-     * Prompts the user to confirm the addition of the book, select a location in the library,
-     * and specify the appropriate bookcase and shelf. Optionally supports batch scanning if
-     * the multi option is enabled.
-     *
-     * @param multi whether to enable batch scanning. If true, the method is configured
-     *              to handle multiple book scans (currently unused). If false, processes a
-     *              single book scan and addition to the library.
-     */
-    @Command(command = "scan", description = "Scan a book's ISBN barcode to retrieve metadata and add it to the library. Use --multi for batch scanning", group = "Book Create Commands")
-    public void createBookScan(@ShellOption(defaultValue = "single") boolean multi) {
-
-//        if (multi) multiBookScan();
-
-        BookMetaDataResponse bookMetaDataResponse = scanBook();
-        String isbn = bookMetaDataResponse.isbn();
-
-        if (cliPrompt.promptToConfirmBookAddition()) {
-            String location = cliPrompt.promptForBookcaseLocation();
-
-            Long bookcaseId = cliPrompt.promptForBookcaseSelection(promptOptions.bookCaseOptionsByLocation(location));
-            if(bookcaseId == null) return;
-
-            Long shelfId = cliPrompt.promptForShelfSelection(bookcaseId);
-            if(shelfId == null) return;
-
-            List<Long> authorIds = createAuthorsFromMetaData(bookMetaDataResponse.authors());
-
-            bookFacade.createBookFromMetaData(bookMetaDataResponse, authorIds, isbn, shelfId);
-
-            String updatedBookCard = bookcardRenderer.createBookCard(bookMetaDataResponse.title(),
-                    bookMetaDataResponse.isbn(),
-                    bookMetaDataResponse.authors().toString(),
-                    bookMetaDataResponse.publisher(),
-                    bookcaseFacade.findBookCaseById(bookcaseId).get().bookcaseLabel(),
-                    shelfFacade.findShelfById(shelfId).get().shelfLabel(),
-                    bookcaseFacade.findBookCaseById(bookcaseId).get().location()
-            );
-            System.out.println(updatedBookCard);
-        }
-    }
-
-    //
-//    private void multiBookScan() {
-//        log.info("Initiating multiBookScan for Multi Scan.");
-//        Long bookcaseId = cliPrompt.promptForBookCase(bookCaseOptions());
-//        Long shelfId = cliPrompt.promptForShelf(bookcaseId);
-//        System.out.println("\n\u001B[95mMulti-Book Scan");
-//        List<String> scans = cliPrompt.promptMultiScan();
-//
-//        for (String isbn : scans) {
-//            System.out.println("Scanned ISBN: " + isbn);
-//
-//            BookMetaDataResponse bookMetaDataResponse = bookFacade.findBookMetaDataByIsbn(isbn);
-//            bookFacade.createBookFromMetaData(bookMetaDataResponse, isbn, shelfId);
-//            System.out.println("\n\u001B[36m</>\033[0m:" + bookMetaDataResponse.title() + " added to Library!");
-//            System.out.println(scans.size() + " books were added to the library.");
-//        }
-//    }
 
     /**
      * Registers a new book entry in the library system. Depending on the provided options,
@@ -147,56 +64,11 @@ public class BookCreateCommands {
 
         ScanMode mode = ScanMode.from(scan, multi);
         switch(mode){
-            case SINGLE -> createBookScan(false);
+//            case SINGLE -> createBookScan(false);
 //            case MULTI -> multiBookScan();
             case NONE -> createBookManually();
         }
     }
-
-
-
-
-    /*  ============================
-        Scan flow helpers
-        ============================
-     */
-
-    /**
-     * Scans a book by prompting the user to enter its ISBN and retrieves metadata associated
-     * with the ISBN from the system. The retrieved metadata includes details like title,
-     * authors, publisher, and description of the book. The method also validates the entered
-     * ISBN and displays a formatted "book card" with the book's metadata to the user.
-     *
-     * @return a {@code BookMetaDataResponse} object containing the metadata for the scanned
-     *         book, or {@code null} if the ISBN is invalid or the process is aborted.
-     */
-    public BookMetaDataResponse scanBook(){
-        log.info("Initiating scanBook for Single Scan.");
-        System.out.println("\n\u001B[95mSingle Book Scan");
-        String isbn = cliPrompt.promptForIsbn();
-        BookMetaDataResponse bookMetaDataResponse = bookFacade.findBookMetaDataByIsbn(isbn);
-        log.debug("BookMetaDataResponse received: {}", bookMetaDataResponse);
-        log.debug("Authors verified/created for book.");
-        log.info(bookMetaDataResponse.toString());
-        System.out.println(
-                bookcardRenderer.createBookCard(bookMetaDataResponse.title(),
-                        bookMetaDataResponse.isbn(),
-                        bookMetaDataResponse.authors().toString(),
-                        bookMetaDataResponse.publisher(),
-                        "PENDING / NOT SET",
-                        "PENDING / NOT SET",
-                        "PENDING / NOT SET")
-        );
-        return bookMetaDataResponse;
-    }
-
-
-
-
-    /* ============================
-        Manual flow helpers
-        ============================
-     */
 
     /**
      * Manually creates a new book entry by prompting the user for input.
@@ -227,13 +99,6 @@ public class BookCreateCommands {
         bookFacade.createNewBook(bookRequestDTO);
     }
 
-
-
-
-    /* ============================
-        Author (manual)
-       ============================
-    */
 
     public List<AuthorDTO> createAuthors(){
         int numberOfAuthors = cliPrompt.promptForBookAuthorCount();
@@ -268,110 +133,5 @@ public class BookCreateCommands {
         }
         log.info("Authors Created and Returned: {}", authors);
         return authors;
-    }
-
-
-
-
-    /* ============================
-        Author (metadata)
-       ============================
-    */
-
-    /**
-     * Creates a list of author IDs by processing a list of author names.
-     * Each name is converted into an AuthorDTO, checked for existence,
-     * and either added as a new author or matched to an existing author.
-     *
-     * @param authorNames a list of strings representing author names, where each name
-     *                    is expected to be in a "FirstName LastName" format
-     * @return a list of author IDs corresponding to the processed authors
-     */
-    public List<Long> createAuthorsFromMetaData(List<String> authorNames){
-        List<Long> authors = new ArrayList<>();
-
-        for (String authorName : authorNames) {
-            AuthorDTO authorDTO = mapAuthorStringToDTO(authorName);
-            boolean exists = authorExists(authorDTO.firstName(), authorDTO.lastName());
-            authors.add(exists ? createNewAuthorOrAddExisting(authorDTO)
-                    : saveNewAuthor(authorDTO).id());
-        }
-        return authors;
-    }
-
-
-
-
-    /* ============================
-        Mapping + facade wrappers
-       ============================
-    */
-
-    /**
-     * Saves a new author to the system database.
-     *
-     * @param authorDTO the data transfer object containing the author's details to be saved
-     * @return the AuthorDTO object corresponding to the newly saved author
-     */
-    public AuthorDTO saveNewAuthor(AuthorDTO authorDTO){
-        return authorFacade.saveAuthor(authorDTO);
-    }
-
-    /**
-     * Converts a given author name string into an AuthorDTO object.
-     * The full name is split into first and last name based on spaces.
-     * If the name contains only one word, it is treated as the first name, and the last name is left empty.
-     *
-     * @param authorName the string representing the author's name, expected in "FirstName LastName" format
-     * @return an AuthorDTO object with firstName and lastName extracted from the input string
-     */
-    public AuthorDTO mapAuthorStringToDTO(String authorName){
-        String[] nameParts = authorName.trim().split(" ");
-        String firstName = nameParts[0];
-        String lastName = nameParts.length > 1 ? nameParts[nameParts.length - 1] : "";
-        return new AuthorDTO(null, firstName, lastName);
-    }
-
-    /**
-     * Creates a new author if the given author does not exist in the system,
-     * or associates an existing author based on user input when multiple matches are found.
-     *
-     * @param authorDTO the data transfer object containing the first name and last name of the author
-     * @return the ID of the newly created or existing author, or null if no valid selection is made
-     */
-    public Long createNewAuthorOrAddExisting(AuthorDTO authorDTO){
-        String firstName = authorDTO.firstName();
-        String lastName = authorDTO.lastName();
-
-        if(authorExists(firstName,lastName)) {
-            log.info("Author already exists: {} {}", authorDTO.firstName(), authorDTO.lastName());
-            System.out.println("Multiple Authors with this name.\n");
-            Long authorId = cliPrompt.promptMultipleAuthorConfirmation(authorDTO);
-            log.info("Existing author selected with ID: {}", authorId);
-            //todo: 0 is a magic number here, refactor needed
-            if (authorId == 0) {
-                log.info("Creating new author as per user request: {} {}", authorDTO.firstName(), authorDTO.lastName());
-                return (authorFacade.saveAuthor(authorDTO).id());
-//                log.info("Author saved: {}", firstName + " " + lastName);
-            } else {
-                log.info("Fetching existing author with ID: {}", authorId);
-
-                AuthorDTO existingAuthor = authorFacade.findById(authorId);
-                return (existingAuthor.id());
-//                log.info("Existing author added to list: {}", existingAuthor);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Checks if an author exists in the system with the given first and last name.
-     *
-     * @param firstName the first name of the author
-     * @param lastName the last name of the author
-     * @return true if an author with the specified first and last name exists, false otherwise
-     */
-    public boolean authorExists(String firstName, String lastName){
-        return authorFacade.authorExistFirstNameLastName(firstName,lastName);
     }
 }

--- a/src/main/java/com/penrose/bibby/cli/command/book/BookCreateScanCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/command/book/BookCreateScanCommands.java
@@ -1,13 +1,11 @@
-package com.penrose.bibby.cli.command.book.create;
+package com.penrose.bibby.cli.command.book;
 
-import com.penrose.bibby.cli.command.book.ScanMode;
 import com.penrose.bibby.cli.prompt.application.CliPromptService;
 import com.penrose.bibby.cli.prompt.domain.PromptOptions;
 import com.penrose.bibby.cli.ui.BookcardRenderer;
 import com.penrose.bibby.library.cataloging.author.contracts.AuthorDTO;
 import com.penrose.bibby.library.cataloging.author.contracts.ports.AuthorFacade;
 import com.penrose.bibby.library.cataloging.book.contracts.dtos.BookMetaDataResponse;
-import com.penrose.bibby.library.cataloging.book.contracts.dtos.BookRequestDTO;
 import com.penrose.bibby.library.cataloging.book.contracts.ports.inbound.BookFacade;
 import com.penrose.bibby.library.stacks.bookcase.contracts.ports.inbound.BookcaseFacade;
 import com.penrose.bibby.library.stacks.shelf.contracts.ports.inbound.ShelfFacade;


### PR DESCRIPTION
This pull request refactors the book creation and scanning functionality in the CLI by extracting all scan-related logic from the existing `BookCreateCommands` class into a new dedicated class, `BookCreateScanCommands`. This separation improves code organization, maintainability, and clarity by isolating scan and metadata-related flows from manual entry and author management.

The most important changes are:

**Refactoring and Code Organization:**
* All scan-related methods, helpers, and dependencies (such as `BookcardRenderer`, `BookcaseFacade`, `ShelfFacade`, and `PromptOptions`) have been moved from `BookCreateCommands` to a new class, `BookCreateScanCommands`, resulting in a cleaner separation of concerns between scanning and manual book creation flows. [[1]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL42-L129) [[2]](diffhunk://#diff-7e153770a868b3f2f4449226a34eba3a76376ab8f107ce7d0c1885834b170004R1-R268)

**Dependency Injection Updates:**
* The constructor of `BookCreateCommands` has been simplified to only require dependencies related to manual book creation, while `BookCreateScanCommands` now receives all dependencies needed for scanning, metadata lookup, and book placement. [[1]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL42-L129) [[2]](diffhunk://#diff-7e153770a868b3f2f4449226a34eba3a76376ab8f107ce7d0c1885834b170004R1-R268)

**Command Endpoint Changes:**
* The `createBookScan` command and its associated helpers (including batch scan stubs and scan metadata display) have been removed from `BookCreateCommands` and re-implemented in `BookCreateScanCommands` with no changes to their core logic. [[1]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL42-L129) [[2]](diffhunk://#diff-7e153770a868b3f2f4449226a34eba3a76376ab8f107ce7d0c1885834b170004R1-R268)

**Author Metadata Handling:**
* Methods for processing authors from metadata (`createAuthorsFromMetaData`, `mapAuthorStringToDTO`, `createNewAuthorOrAddExisting`, `saveNewAuthor`, and `authorExists`) have been moved to `BookCreateScanCommands`, leaving only manual author creation in `BookCreateCommands`. [[1]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL272-L376) [[2]](diffhunk://#diff-7e153770a868b3f2f4449226a34eba3a76376ab8f107ce7d0c1885834b170004R1-R268)

**Code Cleanup:**
* Removed all scan-related comments, helper methods, and unused dependencies from `BookCreateCommands`, resulting in a more focused class for manual book entry and author management. [[1]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL150-L200) [[2]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL231-L237) [[3]](diffhunk://#diff-9a14625d0206ffe2391e274633abbe7cfe0b47ec4b199d79d3fe360143e7f78aL272-L376)

This refactor lays the groundwork for easier future maintenance and potential expansion of both scanning and manual book entry features.