### PR TITLE
feat(cli): implement CSV import for bulk book creation

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/command/library/LibraryCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/command/library/LibraryCommands.java
@@ -5,6 +5,12 @@ import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellOption;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 @ShellComponent
     @Command(command = "library", group = "Library Commands")
 public class LibraryCommands {
@@ -18,9 +24,22 @@ public class LibraryCommands {
     //todo: implement csv import
     @Command(command = "import", description = "Import CSV of ISBNs to add multiple books at once.")
     public void createBooksFromCsv(
-            @ShellOption String filePath){
+            @ShellOption String filePath) throws IOException {
 
         log.info("Importing books from CSV...");
+
+
+        try (BufferedReader reader = Files.newBufferedReader(Path.of(filePath))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+            }
+        }catch (IOException exception) {
+            log.error("Error reading CSV file: {}", exception.getMessage());
+            throw new IOException("Failed to read CSV file", exception);
+        }
+
+
 
     }
 


### PR DESCRIPTION
This pull request adds initial functionality for importing books from a CSV file in the `LibraryCommands` class. The new implementation reads the CSV file line by line and logs any errors encountered during the process.

CSV Import Feature:

* Added logic to the `createBooksFromCsv` method in `LibraryCommands` to read a CSV file line by line using a `BufferedReader`, printing each line to standard output.
* Improved error handling by logging errors and rethrowing an `IOException` if the CSV file cannot be read.

Dependency Updates:

* Imported necessary classes for file and exception handling, including `BufferedReader`, `FileReader`, `IOException`, `Files`, and `Path`.- Added support for importing books via a CSV file in `LibraryCommands`.
- Utilized `BufferedReader` to read and process lines from the specified file path.
- Included error handling for failed CSV reads with appropriate logging.