### PR TITLE
feat(cli): enhance `add` command in BookCreateScanCommands with detai…

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/command/book/BookCreateScanCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/command/book/BookCreateScanCommands.java
@@ -75,7 +75,11 @@ public class BookCreateScanCommands {
      *              to handle multiple book scans (currently unused). If false, processes a
      *              Add Book (ISBN) and addition to the library.
      */
-    @Command(command = "add")
+    @Command(command = "add" , description =
+                """
+                Add books to your library by ISBN (scan/type/paste) or manual entry.
+                If an ISBN is provided, Bibby fetches metadata and creates a new book record. Supports single entry, batch entry, or file import.
+                """)
     public void createBookScan(@ShellOption(defaultValue = "single") boolean multi) {
 
 //        if (multi) multiBookScan();


### PR DESCRIPTION
This pull request updates the CLI command endpoint for adding books in `BookCreateScanCommands.java`. The main change is an improved command description for the `add` command, making it clearer to users how to add books by ISBN or manual entry and what features are supported.

CLI Command Documentation Improvement:

* Updated the `@Command` annotation for the `add` command to include a detailed description, clarifying supported input methods (scan, type, paste, manual entry), metadata fetching, and support for single, batch, or file import.…led description

- Updated the `add` command to include a comprehensive description, outlining support for ISBN input, manual entry, batch entry, and file import.