### PR TITLE
186 review cart notification after add

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/command/book/BookCreateIsbnCommands.java
+++ b/src/main/java/com/penrose/bibby/cli/command/book/BookCreateIsbnCommands.java
@@ -115,6 +115,11 @@ public class BookCreateIsbnCommands {
                             bookcaseFacade.findBookCaseById(bookcaseId).get().location()
                     );
                     System.out.println(updatedBookCard);
+                    System.out.println("\n\033[38;5;42mSuccessfully added to the library\u001B[0m");
+
+                    if(bookMetaDataResponse.publisher() == null || bookMetaDataResponse.publisher().isEmpty()){
+                        System.out.println("\n\033[38;5;3m⚠\u001B[0m Missing Publisher\n");
+                    }
 
                 }
 
@@ -130,9 +135,13 @@ public class BookCreateIsbnCommands {
                         "Not Set"
                 );
                 System.out.println(updatedBookCard);
+                System.out.println("\n\033[38;5;42mSuccessfully added to the library\u001B[0m");
+
                 if(bookMetaDataResponse.publisher() == null || bookMetaDataResponse.publisher().isEmpty()){
-                    System.out.println("\t\u001B[33mAlert: Missing Publisher\u001B[0m\n");
+                    System.out.println("\n\033[38;5;3m⚠\u001B[0m Missing Publisher\n");
                 }
+                System.out.println("\u001B[33mItem in Bookcart. Ready to be shelved.\u001B[0m\n");
+
 
             }
 


### PR DESCRIPTION
This pull request improves user feedback in the `createBookScan` command by adding success and warning messages to the CLI output when books are added to the library. It also adds a notification about the book's status in the bookcart.

User feedback enhancements:

* Added a green-colored success message to inform the user when a book is successfully added to the library. [[1]](diffhunk://#diff-0d7abae3afd97e9fa085563e05c55d82d5072a529962d3bc5d5d4f83baeaff6cR118-R122) [[2]](diffhunk://#diff-0d7abae3afd97e9fa085563e05c55d82d5072a529962d3bc5d5d4f83baeaff6cR138-R144)
* Added a yellow warning message to notify the user if the publisher information is missing when adding a book. [[1]](diffhunk://#diff-0d7abae3afd97e9fa085563e05c55d82d5072a529962d3bc5d5d4f83baeaff6cR118-R122) [[2]](diffhunk://#diff-0d7abae3afd97e9fa085563e05c55d82d5072a529962d3bc5d5d4f83baeaff6cR138-R144)
* Added a message indicating that the item is in the bookcart and ready to be shelved.