### PR TITLE
feat(domain): add `AppUserEntity` for user registration

### DIFF
--- a/src/main/java/com/penrose/bibby/library/registration/appuser/AppUserEntity.java
+++ b/src/main/java/com/penrose/bibby/library/registration/appuser/AppUserEntity.java
@@ -1,0 +1,49 @@
+package com.penrose.bibby.library.registration.appuser;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class AppUserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String username;
+    private String password;
+
+    public AppUserEntity() {
+    }
+
+    public AppUserEntity(Long id, String username, String password) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new JPA entity for representing application users in the registration module. The `AppUserEntity` class models user data with fields for ID, username, and password, and includes standard constructors and getter/setter methods.

New entity introduction:

* Added the `AppUserEntity` class in `com.penrose.bibby.library.registration.appuser`, annotated with `@Entity`, to represent application users with fields for `id`, `username`, and `password` and appropriate constructors and accessor methods.- Introduced `AppUserEntity` class as a JPA entity to represent application users.
- Added fields for `id`, `username`, and `password` with necessary getters and setters.