### PR TITLE
chore(test): add H2 database configuration for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,14 @@
+spring.application.name=Bibby
+
+# H2 in-memory database for testing
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Disable logging during tests
+logging.level.org.springframework=OFF
+logging.level.org.hibernate=OFF
+logging.level.root=OFF


### PR DESCRIPTION
This pull request introduces configuration changes to improve testing for the project. The most important updates are the addition of the H2 in-memory database for test environments and the disabling of logging during tests.

**Testing environment improvements:**

* Added the `com.h2database:h2` dependency with test scope to `pom.xml` to enable H2 in-memory database usage during tests.
* Configured H2 in-memory database settings in `src/test/resources/application.properties`, including connection details and Hibernate dialect for tests.

**Test logging configuration:**

* Disabled logging for Spring, Hibernate, and root logger in the test properties to reduce noise during test execution.- Added `application.properties` for test-specific settings.
- Included H2 database dependency in `pom.xml` for in-memory testing.