### PR TITLE
chore(build): add Spotless plugin for code formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,20 @@
                 </configuration>
             </plugin>
 
+                    <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <configuration>
+                            <ratchetFrom>origin/main</ratchetFrom>
+                            <java>
+                                <googleJavaFormat/>
+                            </java>
+                        </configuration>
+                    </plugin>
+
+
+
 
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This pull request adds a new code formatting plugin to the Maven build configuration to enforce consistent Java code style using Google Java Format.

Build tooling improvements:

* Added the `spotless-maven-plugin` to the `pom.xml` file, configured to check and format Java code according to Google Java Format, helping maintain consistent code style across the project.- Integrated `spotless-maven-plugin` with Google Java Format to enforce consistent code style.
- Configured ratcheting to apply formatting to new changes only.