### PR TITLE
Chore/create dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Build Image
-FROM maven:3-openjdk-21 AS stage
+FROM maven:3-openjdk-21 AS build
 
 WORKDIR /app
 COPY pom.xml .


### PR DESCRIPTION
This pull request adds a multi-stage `Dockerfile` to the project, enabling containerized builds and deployments for the Java application. The `Dockerfile` uses Maven for building and formatting checks, and creates a lightweight runtime image using Eclipse Temurin.

Docker support:

* Added a multi-stage `Dockerfile` that builds the Java application using Maven (`maven:3-openjdk-21`), runs formatting checks (`spotless:check`), and packages the app. The final image uses `eclipse-temurin:21-jre` for a minimal runtime environment, copying the built JAR and setting the default command to run the application.