### PR TITLE
chore(pom): format XML and add Spring Boot Actuator dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.5.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.penrose</groupId>
     <artifactId>Bibby</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Bibby</name>
     <description>Bibby</description>
-    <url/>
+    <url />
     <licenses>
-        <license/>
+        <license />
     </licenses>
     <developers>
-        <developer/>
+        <developer />
     </developers>
     <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
+        <connection />
+        <developerConnection />
+        <tag />
+        <url />
     </scm>
     <properties>
         <java.version>17</java.version>
@@ -35,6 +36,7 @@
             <groupId>org.springframework.shell</groupId>
             <artifactId>spring-shell-starter</artifactId>
         </dependency>
+
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -74,6 +76,12 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -117,23 +125,22 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/5.17.0/mockito-core-5.17.0.jar</argLine>
+                    <argLine>
+                        -javaagent:${settings.localRepository}/org/mockito/mockito-core/5.17.0/mockito-core-5.17.0.jar</argLine>
                 </configuration>
             </plugin>
 
-                    <plugin>
-                        <groupId>com.diffplug.spotless</groupId>
-                        <artifactId>spotless-maven-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <configuration>
-                            <ratchetFrom>origin/main</ratchetFrom>
-                            <java>
-                                <googleJavaFormat/>
-                            </java>
-                        </configuration>
-                    </plugin>
-
-
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <ratchetFrom>origin/main</ratchetFrom>
+                    <java>
+                        <googleJavaFormat />
+                    </java>
+                </configuration>
+            </plugin>
 
 
             <plugin>


### PR DESCRIPTION
This pull request updates the `pom.xml` file with several dependency and formatting changes. The main update is the addition of the Spring Boot Actuator dependency, which enables production-ready features such as monitoring and metrics. Other changes include minor formatting improvements and adjustments to plugin configuration.

**Dependency updates:**

* Added `spring-boot-starter-actuator` dependency to enable application monitoring and management endpoints.

**Formatting and configuration:**

* Improved XML formatting for readability, including indentation and line breaks in the project declaration.
* Added a line break for better separation between dependencies.
* Reformatted the `argLine` configuration for the `maven-surefire-plugin` to use multi-line XML for clarity.
* Removed unnecessary blank lines before the `spring-boot-maven-plugin` configuration section.