### PR TITLE
chore(ci): update Docker login password to use GHCR_PAT for improved …

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Extract metadata (tags, labels)
         id: meta


### PR DESCRIPTION
This pull request makes a minor update to the authentication method used in the image publishing workflow. The password for the container registry login step in `.github/workflows/publish-image.yml` is now set to use the `GHCR_PAT` secret instead of the default `GITHUB_TOKEN`. This change improves security and ensures compatibility with GitHub Container Registry requirements.…security