### PR TITLE
Feature/isbn autofill api

### DIFF
--- a/src/main/java/com/penrose/bibby/library/cataloging/book/infrastructure/external/GoogleBookResponseBrief.java
+++ b/src/main/java/com/penrose/bibby/library/cataloging/book/infrastructure/external/GoogleBookResponseBrief.java
@@ -2,5 +2,4 @@ package com.penrose.bibby.library.cataloging.book.infrastructure.external;
 
 import java.util.List;
 
-public record GoogleBookResponseBrief(String isbn, String title, List<String> authors) {
-}
+public record GoogleBookResponseBrief(String isbn, String title, List<String> authors) {}

--- a/src/main/java/com/penrose/bibby/web/book/BookImportController.java
+++ b/src/main/java/com/penrose/bibby/web/book/BookImportController.java
@@ -1,72 +1,70 @@
 package com.penrose.bibby.web.book;
 
-import com.penrose.bibby.library.cataloging.book.contracts.dtos.BookMetaDataResponse;
-import com.penrose.bibby.library.cataloging.book.infrastructure.entity.BookEntity;
+import com.penrose.bibby.library.cataloging.book.core.application.IsbnEnrichmentService;
+import com.penrose.bibby.library.cataloging.book.core.application.IsbnLookupService;
 import com.penrose.bibby.library.cataloging.book.infrastructure.external.BookImportRequest;
 import com.penrose.bibby.library.cataloging.book.infrastructure.external.GoogleBookResponseBrief;
 import com.penrose.bibby.library.cataloging.book.infrastructure.external.GoogleBooksResponse;
-import com.penrose.bibby.library.cataloging.book.core.application.IsbnLookupService;
-import com.penrose.bibby.library.cataloging.book.core.application.IsbnEnrichmentService;
 import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @RestController
 public class BookImportController {
-    Logger log = org.slf4j.LoggerFactory.getLogger(BookImportController.class);
+  Logger log = org.slf4j.LoggerFactory.getLogger(BookImportController.class);
 
-    private final IsbnLookupService isbnLookupService;
-    private final IsbnEnrichmentService isbnEnrichmentService;
+  private final IsbnLookupService isbnLookupService;
+  private final IsbnEnrichmentService isbnEnrichmentService;
 
-    public BookImportController(IsbnLookupService isbnLookupService, IsbnEnrichmentService isbnEnrichmentService) {
-        this.isbnLookupService = isbnLookupService;
-        this.isbnEnrichmentService = isbnEnrichmentService;
+  public BookImportController(
+      IsbnLookupService isbnLookupService, IsbnEnrichmentService isbnEnrichmentService) {
+    this.isbnLookupService = isbnLookupService;
+    this.isbnEnrichmentService = isbnEnrichmentService;
+  }
+
+  @PostMapping("/api/v1/books/fetchbookmetadata")
+  public ResponseEntity<GoogleBookResponseBrief> importBook(
+      @RequestBody BookImportRequest request) {
+    if (request == null || request.isbn() == null || request.isbn().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ISBN is required");
     }
 
-    @PostMapping("/api/v1/books/fetchbookmetadata")
-    public ResponseEntity<GoogleBookResponseBrief> importBook(@RequestBody BookImportRequest request) {
-        if (request == null || request.isbn() == null || request.isbn().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ISBN is required");
-        }
+    log.info("Import request for ISBN {}", request.isbn());
 
-        log.info("Import request for ISBN {}", request.isbn());
-
-        GoogleBooksResponse lookupResponse = isbnLookupService.lookupBook(request.isbn()).block();
-        if (lookupResponse == null || lookupResponse.items() == null || lookupResponse.items().isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No book found for ISBN " + request.isbn());
-        }
-
-        GoogleBookResponseBrief googleBookResponseBrief = new GoogleBookResponseBrief(
-                request.isbn(), lookupResponse.items().get(0).volumeInfo().title(),
-                lookupResponse.items().get(0).volumeInfo().authors()
-        );
-        log.info("Found book metadata for ISBN {}: {}", request.isbn(), googleBookResponseBrief);
-
-
-
-
-//        BookEntity savedBook = isbnEnrichmentService.enrichIsbn(lookupResponse, request.isbn());
-//        List<String> authors = savedBook.getAuthors().stream()
-//                .map(author -> author.getFirstName() + " " + author.getLastName())
-//                .collect(Collectors.toList());
-//
-//        BookMetaDataResponse response = new BookMetaDataResponse(
-//                savedBook.getBookId(),
-//                savedBook.getTitle(),
-//                savedBook.getIsbn(),
-//                authors,
-//                savedBook.getPublisher(),
-//                Optional.ofNullable(savedBook.getDescription())
-//        );
-
-        return ResponseEntity.ok(googleBookResponseBrief);
+    GoogleBooksResponse lookupResponse = isbnLookupService.lookupBook(request.isbn()).block();
+    if (lookupResponse == null
+        || lookupResponse.items() == null
+        || lookupResponse.items().isEmpty()) {
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "No book found for ISBN " + request.isbn());
     }
+
+    GoogleBookResponseBrief googleBookResponseBrief =
+        new GoogleBookResponseBrief(
+            request.isbn(),
+            lookupResponse.items().get(0).volumeInfo().title(),
+            lookupResponse.items().get(0).volumeInfo().authors());
+    log.info("Found book metadata for ISBN {}: {}", request.isbn(), googleBookResponseBrief);
+
+    //        BookEntity savedBook = isbnEnrichmentService.enrichIsbn(lookupResponse,
+    // request.isbn());
+    //        List<String> authors = savedBook.getAuthors().stream()
+    //                .map(author -> author.getFirstName() + " " + author.getLastName())
+    //                .collect(Collectors.toList());
+    //
+    //        BookMetaDataResponse response = new BookMetaDataResponse(
+    //                savedBook.getBookId(),
+    //                savedBook.getTitle(),
+    //                savedBook.getIsbn(),
+    //                authors,
+    //                savedBook.getPublisher(),
+    //                Optional.ofNullable(savedBook.getDescription())
+    //        );
+
+    return ResponseEntity.ok(googleBookResponseBrief);
+  }
 }


### PR DESCRIPTION
This pull request updates the book import endpoint to simplify its response and introduces a new DTO for returning brief book metadata. The main focus is on returning essential book information (ISBN, title, authors) directly from the Google Books API, rather than enriching and saving the book in the database. The most important changes are:

**API Endpoint Changes:**

* Changed the endpoint from `/import/books` to `/api/v1/books/fetchbookmetadata` and updated the controller to return a `GoogleBookResponseBrief` instead of the more detailed `BookMetaDataResponse`.

**DTO and Data Structure Updates:**

* Added a new record, `GoogleBookResponseBrief`, to encapsulate brief book metadata (ISBN, title, authors).
* Updated the controller to construct and return a `GoogleBookResponseBrief` using data from the Google Books API response, removing the logic that enriched and persisted the book entity.

**Dependency and Import Adjustments:**

* Imported the new `GoogleBookResponseBrief` DTO into the controller.