### PR TITLE
refactor(service): rename BCryptPasswordEncoder variable for consistency

### DIFF
--- a/src/main/java/com/penrose/bibby/library/registration/UserRegistrationService.java
+++ b/src/main/java/com/penrose/bibby/library/registration/UserRegistrationService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 public class UserRegistrationService {
 
   private final UserRegistrationJpaRepository userRegistrationJpaRepository;
-  private final BCryptPasswordEncoder Bcrypt = new BCryptPasswordEncoder(14);
+  private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder(14);
 
   public UserRegistrationService(UserRegistrationJpaRepository userRegistrationJpaRepository) {
     this.userRegistrationJpaRepository = userRegistrationJpaRepository;
@@ -15,7 +15,7 @@ public class UserRegistrationService {
 
   public RegisterUserResult registerUser(RegisterUserCommand registerUserCommand) {
     AppUserEntity appUserEntity = AppUserMapper.toEntity(registerUserCommand);
-    appUserEntity.setPassword(Bcrypt.encode(registerUserCommand.password()));
+    appUserEntity.setPassword(bCryptPasswordEncoder.encode(registerUserCommand.password()));
     appUserEntity = userRegistrationJpaRepository.save(appUserEntity);
     return new RegisterUserResult(appUserEntity.getId(), appUserEntity.getEmail());
   }


### PR DESCRIPTION
This pull request makes a small code quality improvement by renaming a field in the `UserRegistrationService` class for consistency and clarity.

- Renamed the `BCryptPasswordEncoder` field from `Bcrypt` to `bCryptPasswordEncoder` to follow Java naming conventions and improve code readability.