### PR TITLE
Feature(api)/create new bookcase endpoint

### DIFF
--- a/src/main/java/com/penrose/bibby/library/stacks/bookcase/contracts/CreateBookcaseResult.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/bookcase/contracts/CreateBookcaseResult.java
@@ -1,5 +1,3 @@
 package com.penrose.bibby.library.stacks.bookcase.contracts;
 
-
-public record CreateBookcaseResult(Long bookcaseId) {
-}
+public record CreateBookcaseResult(Long bookcaseId) {}

--- a/src/main/java/com/penrose/bibby/library/stacks/bookcase/contracts/dtos/CreateBookcaseRequest.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/bookcase/contracts/dtos/CreateBookcaseRequest.java
@@ -1,4 +1,4 @@
 package com.penrose.bibby.library.stacks.bookcase.contracts.dtos;
 
-public record CreateBookcaseRequest(String location, String zone, String indexId, int shelfCount, int shelfCapacity) {
-}
+public record CreateBookcaseRequest(
+    String location, String zone, String indexId, int shelfCount, int shelfCapacity) {}

--- a/src/main/java/com/penrose/bibby/library/stacks/bookcase/contracts/ports/inbound/BookcaseFacade.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/bookcase/contracts/ports/inbound/BookcaseFacade.java
@@ -3,25 +3,30 @@ package com.penrose.bibby.library.stacks.bookcase.contracts.ports.inbound;
 import com.penrose.bibby.library.stacks.bookcase.contracts.CreateBookcaseResult;
 import com.penrose.bibby.library.stacks.bookcase.contracts.dtos.BookcaseDTO;
 import com.penrose.bibby.library.stacks.bookcase.infrastructure.BookcaseEntity;
-
 import java.util.List;
 import java.util.Optional;
 
 public interface BookcaseFacade {
-    Optional<BookcaseDTO> findBookCaseById(Long aLong);
+  Optional<BookcaseDTO> findBookCaseById(Long aLong);
 
-    /**
-     * Retrieves a list of all bookcases in the library.
-     *
-     * @return A list of BookcaseDTO objects representing all bookcases.
-     */
-    List<BookcaseDTO> getAllBookcases();
+  /**
+   * Retrieves a list of all bookcases in the library.
+   *
+   * @return A list of BookcaseDTO objects representing all bookcases.
+   */
+  List<BookcaseDTO> getAllBookcases();
 
-    CreateBookcaseResult createNewBookCase(String bookcaseLabel, String bookcaseZone, String bookcaseZoneIndex, int shelfCount, int bookCapacity, String location);
+  CreateBookcaseResult createNewBookCase(
+      String bookcaseLabel,
+      String bookcaseZone,
+      String bookcaseZoneIndex,
+      int shelfCount,
+      int bookCapacity,
+      String location);
 
-    List<String> getAllBookcaseLocations();
+  List<String> getAllBookcaseLocations();
 
-    Optional<BookcaseEntity> findById(Long bookcaseId);
+  Optional<BookcaseEntity> findById(Long bookcaseId);
 
-    List<BookcaseDTO> getAllBookcasesByLocation(String location);
+  List<BookcaseDTO> getAllBookcasesByLocation(String location);
 }

--- a/src/main/java/com/penrose/bibby/library/stacks/bookcase/core/application/BookcaseService.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/bookcase/core/application/BookcaseService.java
@@ -1,4 +1,5 @@
 package com.penrose.bibby.library.stacks.bookcase.core.application;
+
 import com.penrose.bibby.library.stacks.bookcase.contracts.CreateBookcaseResult;
 import com.penrose.bibby.library.stacks.bookcase.contracts.dtos.BookcaseDTO;
 import com.penrose.bibby.library.stacks.bookcase.contracts.ports.inbound.BookcaseFacade;
@@ -6,97 +7,115 @@ import com.penrose.bibby.library.stacks.bookcase.infrastructure.BookcaseEntity;
 import com.penrose.bibby.library.stacks.bookcase.infrastructure.BookcaseRepository;
 import com.penrose.bibby.library.stacks.shelf.core.domain.ShelfFactory;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.repository.ShelfJpaRepository;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
-import java.util.Optional;
-
 @Service
 public class BookcaseService implements BookcaseFacade {
-    private final ShelfFactory shelfFactory;
-    private static final Logger log = LoggerFactory.getLogger(BookcaseService.class);
-    private final BookcaseRepository bookcaseRepository;
-    private final ResponseStatusException existingRecordError = new ResponseStatusException(HttpStatus.CONFLICT, "Bookcase with the label already exist");
-    private final ShelfJpaRepository shelfJpaRepository;
+  private final ShelfFactory shelfFactory;
+  private static final Logger log = LoggerFactory.getLogger(BookcaseService.class);
+  private final BookcaseRepository bookcaseRepository;
+  private final ResponseStatusException existingRecordError =
+      new ResponseStatusException(HttpStatus.CONFLICT, "Bookcase with the label already exist");
+  private final ShelfJpaRepository shelfJpaRepository;
 
-    public BookcaseService(BookcaseRepository bookcaseRepository, ShelfJpaRepository shelfJpaRepository, ShelfFactory shelfFactory) {
-        this.bookcaseRepository = bookcaseRepository;
-        this.shelfJpaRepository = shelfJpaRepository;
-        this.shelfFactory = shelfFactory;
+  public BookcaseService(
+      BookcaseRepository bookcaseRepository,
+      ShelfJpaRepository shelfJpaRepository,
+      ShelfFactory shelfFactory) {
+    this.bookcaseRepository = bookcaseRepository;
+    this.shelfJpaRepository = shelfJpaRepository;
+    this.shelfFactory = shelfFactory;
+  }
+
+  public CreateBookcaseResult createNewBookCase(
+      String label,
+      String bookcaseZone,
+      String bookcaseZoneIndex,
+      int shelfCapacity,
+      int bookCapacity,
+      String location) {
+    BookcaseEntity bookcaseEntity = bookcaseRepository.findBookcaseEntityByBookcaseLabel(label);
+    if (bookcaseEntity != null) {
+      log.error("Failed to save Record - Record already exist", existingRecordError);
+      throw existingRecordError;
+    } else {
+      bookcaseEntity =
+          new BookcaseEntity(
+              location,
+              bookcaseZone,
+              bookcaseZoneIndex,
+              shelfCapacity,
+              bookCapacity * shelfCapacity);
+      bookcaseEntity = bookcaseRepository.save(bookcaseEntity);
+
+      for (int i = 0; i < bookcaseEntity.getShelfCapacity(); i++) {
+        addShelf(bookcaseEntity, i, i, bookCapacity);
+      }
+
+      CreateBookcaseResult createBookcaseResult =
+          new CreateBookcaseResult(bookcaseEntity.getBookcaseId());
+      log.info("Created new bookcase with Id: {}", createBookcaseResult.bookcaseId());
+
+      return createBookcaseResult;
     }
+  }
 
-    public CreateBookcaseResult createNewBookCase(String label, String bookcaseZone , String bookcaseZoneIndex, int shelfCapacity, int bookCapacity, String location) {
-        BookcaseEntity bookcaseEntity = bookcaseRepository.findBookcaseEntityByBookcaseLabel(label);
-        if (bookcaseEntity != null) {
-            log.error("Failed to save Record - Record already exist", existingRecordError);
-            throw existingRecordError;
-        } else {
-            bookcaseEntity = new BookcaseEntity(location,bookcaseZone,bookcaseZoneIndex,shelfCapacity, bookCapacity * shelfCapacity);
-            bookcaseEntity = bookcaseRepository.save(bookcaseEntity);
+  @Override
+  public List<String> getAllBookcaseLocations() {
+    return bookcaseRepository.getAllBookCaseLocations();
+  }
 
-            for (int i = 0; i < bookcaseEntity.getShelfCapacity(); i++) {
-                addShelf(bookcaseEntity, i, i, bookCapacity);
-            }
+  @Override
+  public Optional<BookcaseEntity> findById(Long bookcaseId) {
+    return bookcaseRepository.findById(bookcaseId);
+  }
 
-            CreateBookcaseResult createBookcaseResult = new CreateBookcaseResult(bookcaseEntity.getBookcaseId());
-            log.info("Created new bookcase with Id: {}", createBookcaseResult.bookcaseId());
+  @Override
+  public List<BookcaseDTO> getAllBookcasesByLocation(String location) {
+    return bookcaseRepository.findByLocation(location).stream()
+        .map(
+            entity ->
+                new BookcaseDTO(
+                    entity.getBookcaseId(),
+                    entity.getBookcaseLabel(),
+                    entity.getShelfCapacity(),
+                    entity.getBookCapacity(),
+                    entity.getBookcaseLocation()))
+        .toList();
+  }
 
-            return createBookcaseResult;
-        }
+  public void addShelf(BookcaseEntity bookcaseEntity, int label, int position, int bookCapacity) {
+    shelfJpaRepository.save(
+        shelfFactory.createEntity(
+            bookcaseEntity.getBookcaseId(), position, "Shelf " + label, bookCapacity));
+  }
+
+  public List<BookcaseDTO> getAllBookcases() {
+    List<BookcaseEntity> bookcaseEntities = bookcaseRepository.findAll();
+    return bookcaseEntities.stream()
+        .map(
+            entity ->
+                new BookcaseDTO(
+                    entity.getBookcaseId(),
+                    entity.getBookcaseLabel(),
+                    entity.getShelfCapacity(),
+                    entity.getBookCapacity(),
+                    entity.getBookcaseLocation()))
+        .toList();
+  }
+
+  public Optional<BookcaseDTO> findBookCaseById(Long id) {
+    Optional<BookcaseEntity> bookcaseEntity = bookcaseRepository.findById(id);
+
+    if (bookcaseEntity.isEmpty()) {
+      return Optional.empty();
     }
-
-    @Override
-    public List<String> getAllBookcaseLocations() {
-        return bookcaseRepository.getAllBookCaseLocations();
-    }
-
-    @Override
-    public Optional<BookcaseEntity> findById(Long bookcaseId) {
-        return bookcaseRepository.findById(bookcaseId);
-    }
-
-    @Override
-    public List<BookcaseDTO> getAllBookcasesByLocation(String location) {
-        return bookcaseRepository.findByLocation(location).stream()
-                .map(entity -> new BookcaseDTO(
-                        entity.getBookcaseId(),
-                        entity.getBookcaseLabel(),
-                        entity.getShelfCapacity(),
-                        entity.getBookCapacity(),
-                        entity.getBookcaseLocation()
-                ))
-                .toList();
-    }
-
-    public void addShelf(BookcaseEntity bookcaseEntity, int label, int position, int bookCapacity) {
-        shelfJpaRepository.save(shelfFactory.createEntity(bookcaseEntity.getBookcaseId(), position, "Shelf " + label, bookCapacity));
-    }
-
-    public List<BookcaseDTO> getAllBookcases() {
-        List<BookcaseEntity> bookcaseEntities = bookcaseRepository.findAll();
-        return bookcaseEntities.stream()
-                .map(entity -> new BookcaseDTO(
-                        entity.getBookcaseId(),
-                        entity.getBookcaseLabel(),
-                        entity.getShelfCapacity(),
-                        entity.getBookCapacity(),
-                        entity.getBookcaseLocation()
-                ))
-                .toList();
-    }
-
-
-    public Optional<BookcaseDTO> findBookCaseById(Long id) {
-        Optional<BookcaseEntity> bookcaseEntity = bookcaseRepository.findById(id);
-
-        if (bookcaseEntity.isEmpty()) {
-            return Optional.empty();
-        }
-        return BookcaseDTO.fromEntity(bookcaseEntity);
-    }
-
+    return BookcaseDTO.fromEntity(bookcaseEntity);
+  }
 }

--- a/src/main/java/com/penrose/bibby/library/stacks/bookcase/infrastructure/BookcaseRepository.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/bookcase/infrastructure/BookcaseRepository.java
@@ -1,23 +1,18 @@
 package com.penrose.bibby.library.stacks.bookcase.infrastructure;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Repository;
-
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-
 public interface BookcaseRepository {
-    BookcaseEntity findBookcaseEntityByBookcaseLabel(String s);
-    List<BookcaseEntity> findAll();
+  BookcaseEntity findBookcaseEntityByBookcaseLabel(String s);
 
-    List<String> getAllBookCaseLocations();
+  List<BookcaseEntity> findAll();
 
-    BookcaseEntity save(BookcaseEntity bookcaseEntity);
+  List<String> getAllBookCaseLocations();
 
-    Optional<BookcaseEntity> findById(Long id);
+  BookcaseEntity save(BookcaseEntity bookcaseEntity);
 
-    List<BookcaseEntity> findByLocation(String location);
+  Optional<BookcaseEntity> findById(Long id);
+
+  List<BookcaseEntity> findByLocation(String location);
 }

--- a/src/main/java/com/penrose/bibby/library/stacks/bookcase/infrastructure/BookcaseRepositoryImpl.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/bookcase/infrastructure/BookcaseRepositoryImpl.java
@@ -1,53 +1,50 @@
 package com.penrose.bibby.library.stacks.bookcase.infrastructure;
 
-import org.springframework.stereotype.Repository;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
 @Repository
-public class BookcaseRepositoryImpl implements BookcaseRepository{
-    BookcaseJpaRepository bookcaseJpaRepository;
+public class BookcaseRepositoryImpl implements BookcaseRepository {
+  BookcaseJpaRepository bookcaseJpaRepository;
 
-    public BookcaseRepositoryImpl(BookcaseJpaRepository bookcaseJpaRepository) {
-        this.bookcaseJpaRepository = bookcaseJpaRepository;
+  public BookcaseRepositoryImpl(BookcaseJpaRepository bookcaseJpaRepository) {
+    this.bookcaseJpaRepository = bookcaseJpaRepository;
+  }
+
+  @Override
+  public BookcaseEntity findBookcaseEntityByBookcaseLabel(String s) {
+    return bookcaseJpaRepository.findBookcaseEntityByBookcaseLabel(s);
+  }
+
+  @Override
+  public List<BookcaseEntity> findAll() {
+    return bookcaseJpaRepository.findAll();
+  }
+
+  @Override
+  public List<String> getAllBookCaseLocations() {
+    List<String> locations = new ArrayList<>();
+    List<BookcaseEntity> bookcaseEntities = bookcaseJpaRepository.findAll();
+    for (BookcaseEntity entity : bookcaseEntities) {
+      locations.add(entity.getBookcaseLocation());
     }
+    return locations;
+  }
 
-    @Override
-    public BookcaseEntity findBookcaseEntityByBookcaseLabel(String s) {
-        return bookcaseJpaRepository.findBookcaseEntityByBookcaseLabel(s);
-    }
+  @Override
+  public BookcaseEntity save(BookcaseEntity bookcaseEntity) {
+    return bookcaseJpaRepository.save(bookcaseEntity);
+  }
 
-    @Override
-    public List<BookcaseEntity> findAll() {
-        return bookcaseJpaRepository.findAll();
-    }
+  @Override
+  public Optional<BookcaseEntity> findById(Long id) {
+    return bookcaseJpaRepository.findById(id);
+  }
 
-    @Override
-    public List<String> getAllBookCaseLocations() {
-        List<String> locations = new ArrayList<>();
-        List<BookcaseEntity> bookcaseEntities = bookcaseJpaRepository.findAll();
-        for (BookcaseEntity entity : bookcaseEntities) {
-            locations.add(entity.getBookcaseLocation());
-        }
-        return locations;
-    }
-
-    @Override
-    public BookcaseEntity save(BookcaseEntity bookcaseEntity) {
-       return bookcaseJpaRepository.save(bookcaseEntity);
-    }
-
-    @Override
-    public Optional<BookcaseEntity> findById(Long id) {
-        return bookcaseJpaRepository.findById(id);
-    }
-
-
-
-    @Override
-    public List<BookcaseEntity> findByLocation(String location) {
-        return bookcaseJpaRepository.findAllByBookcaseLocation(location);
-    }
+  @Override
+  public List<BookcaseEntity> findByLocation(String location) {
+    return bookcaseJpaRepository.findAllByBookcaseLocation(location);
+  }
 }

--- a/src/main/java/com/penrose/bibby/web/bookcase/BookCaseController.java
+++ b/src/main/java/com/penrose/bibby/web/bookcase/BookCaseController.java
@@ -15,19 +15,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/bookcase")
 public class BookCaseController {
-    Logger logger = LoggerFactory.getLogger(BookCaseController.class);
-    BookcaseService bookCaseService;
+  Logger logger = LoggerFactory.getLogger(BookCaseController.class);
+  BookcaseService bookCaseService;
 
-    public BookCaseController(BookcaseService bookCaseService) {
-        this.bookCaseService = bookCaseService;
-    }
+  public BookCaseController(BookcaseService bookCaseService) {
+    this.bookCaseService = bookCaseService;
+  }
 
-    @PostMapping("/create")
-    public ResponseEntity<CreateBookcaseResult> createBookCase(@RequestBody CreateBookcaseRequest createBookcaseRequest){
-        logger.info("Received request to create bookcase at location: {}", createBookcaseRequest.location());
-        CreateBookcaseResult createBookcaseResult = bookCaseService.createNewBookCase(null, createBookcaseRequest.zone(), createBookcaseRequest.indexId(), createBookcaseRequest.shelfCount(), createBookcaseRequest.shelfCapacity(),createBookcaseRequest.location());
+  @PostMapping("/create")
+  public ResponseEntity<CreateBookcaseResult> createBookCase(
+      @RequestBody CreateBookcaseRequest createBookcaseRequest) {
+    logger.info(
+        "Received request to create bookcase at location: {}", createBookcaseRequest.location());
+    CreateBookcaseResult createBookcaseResult =
+        bookCaseService.createNewBookCase(
+            null,
+            createBookcaseRequest.zone(),
+            createBookcaseRequest.indexId(),
+            createBookcaseRequest.shelfCount(),
+            createBookcaseRequest.shelfCapacity(),
+            createBookcaseRequest.location());
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(createBookcaseResult);
-    }
-
+    return ResponseEntity.status(HttpStatus.CREATED).body(createBookcaseResult);
+  }
 }


### PR DESCRIPTION
This pull request refactors the bookcase creation flow to use a new request and response structure, improving type safety and API clarity. The main changes include introducing `CreateBookcaseRequest` and `CreateBookcaseResult` records, updating the controller and service to use these types, and adjusting repository and interface methods accordingly.

**API and DTO Refactoring:**

* Added `CreateBookcaseRequest` and `CreateBookcaseResult` records to represent the request and response for creating a bookcase, replacing the previous use of loosely-typed parameters and string responses (`CreateBookcaseRequest.java`, `CreateBookcaseResult.java`). [[1]](diffhunk://#diff-5ae9b6200ab64fd96f22028f8d56f170f9aaea8511cc0f59eaef9c76f7ed1dd2R1-R4) [[2]](diffhunk://#diff-6b690e3f6ceb4d678ec900196077d14f2bf624f09b5d8d6d5dc3621d86a287f8R1-R3)

* Updated `BookCaseController` to accept a `CreateBookcaseRequest` and return a `CreateBookcaseResult`, replacing the previous approach that used `BookcaseDTO` and returned a string message. Also added logging and changed the endpoint to `/api/v1/bookcase/create` (`BookCaseController.java`).

**Service and Interface Updates:**

* Refactored `BookcaseFacade` and `BookcaseService` to use the new `CreateBookcaseResult` return type for `createNewBookCase`, and updated method signatures and implementation to match the new request/response pattern (`BookcaseFacade.java`, `BookcaseService.java`). [[1]](diffhunk://#diff-6de022c904c1d56b0e97ba01a1b1de997dfdc40fed46e5958395771348010ca1L19-R25) [[2]](diffhunk://#diff-69dd5572711fdb60542b28678b4b4683d8f78f1206782b0e3b4efc4f776d5670R2-R65)

**Repository Adjustments:**

* Changed the `save` method in `BookcaseRepository` and its implementation to return the saved `BookcaseEntity` instead of void, enabling the service to return the new bookcase's ID (`BookcaseRepository.java`, `BookcaseRepositoryImpl.java`). [[1]](diffhunk://#diff-6e2b4f0914f5179eef5313a87301ebc520e9ba4445b4663cb10bc470ad33eb0aL3-R13) [[2]](diffhunk://#diff-1390f9372001f8feb22271e7f23e2dcd9bb5ca8144fefc797f041f87d79c5083L38-L48)