### PR TITLE
refactor: move validation logic into domain entities and clean up She…

### DIFF
--- a/docs/the-devlogs/devlog-2026-02-18-ShelfFactory-to-ShelfFacade-Refactor.md
+++ b/docs/the-devlogs/devlog-2026-02-18-ShelfFactory-to-ShelfFacade-Refactor.md
@@ -1,0 +1,172 @@
+# Devlog: ShelfFactory to ShelfFacade Refactor
+
+**Date:** 2026-02-18
+**Branch:** `refactor/shelf-factory-to-facade`
+**Theme:** Facade Pattern / Decoupling / Domain Cleanup
+
+---
+
+## Context
+
+`ShelfFactory` had been sitting in the domain layer doing a simple job: stamp out `ShelfEntity` instances with a few setter calls. It worked, but it carried the wrong kind of weight. Factory classes living in the domain that reach down into infrastructure are a layering smell — domain shouldn't know about entities, and a factory that only sets four fields is more overhead than it's worth.
+
+This refactor replaces the factory with a proper `createShelf()` method behind the existing `ShelfFacade` interface. The result is a simpler dependency graph, better-validated shelf creation, and a cleaner `BookcaseService` that delegates through the facade instead of juggling a raw JPA repository and a factory bean side-by-side.
+
+A secondary cleanup removed `BookcaseFacade` from `ShelfService`, which had crept in to support `toShelfOption()` but introduced a circular-style dependency between two services in the same bounded context.
+
+---
+
+## Commit Breakdown
+
+### Commit 1: `662425a` — Replace ShelfFactory with ShelfFacade pattern
+
+**Files changed:** 9 files, +907 lines, -142 lines
+
+**Domain (`Shelf.java`):**
+- Reorganized class into clear sections: fields → constructor → business logic → getters/setters → object methods
+- Fixed a null-safety bug in `isFull()` — previously would NPE if `bookIds` was null; now guards with `bookIds != null`
+- Removed the no-arg default constructor (construction now goes through the canonical constructor)
+
+**Application (`ShelfService.java`):**
+- Added `createShelf(Long bookcaseId, int position, String shelfLabel, int bookCapacity)` implementation
+- Validation guards: `bookCapacity <= 0`, blank/null `shelfLabel`, `position < 0`
+- Entity instantiation uses an anonymous initializer block — functional, though flagged as a candidate for a builder pattern later
+- Added `createShelf()` signature to `ShelfFacade` interface
+
+**Application (`BookcaseService.java`):**
+- Dropped `ShelfJpaRepository` and `ShelfFactory` dependencies
+- Now delegates shelf creation to `ShelfFacade.createShelf()`
+- Added validation for `bookCapacity`, `bookcaseEntity`, `position`, and `label` before delegating
+
+**Infrastructure (`ShelfMapper.java`):**
+- `toDomain()` updated to use the canonical constructor instead of chained setters — simpler and ensures all required fields are set at construction time
+- Removed dead `updateEntity()` method (was a pass-through that did nothing)
+
+**Tests:**
+- `ShelfServiceTest`: 10 new test cases covering all validation paths and happy-path creation
+- `BookcaseServiceTest`: comprehensive service-layer test coverage (450 lines)
+
+---
+
+### Commit 2: `7179599` — Complete removal of ShelfFactory.java
+
+**Files changed:** 1 file, -18 lines
+
+Deleted `ShelfFactory` from the infrastructure package. The class had been moved there in a prior step as a staging area before full removal. This commit finishes the job — no references remain.
+
+**Before:**
+```java
+@Component
+public class ShelfFactory {
+    public ShelfEntity createEntity(Long bookCaseId, int shelfPosition, String shelfLabel, int bookCapacity) {
+        ShelfEntity shelfEntity = new ShelfEntity();
+        shelfEntity.setBookcaseId(bookCaseId);
+        shelfEntity.setShelfLabel(shelfLabel);
+        shelfEntity.setShelfPosition(shelfPosition);
+        shelfEntity.setBookCapacity(bookCapacity);
+        return shelfEntity;
+    }
+}
+```
+
+**After:** File deleted. `ShelfService.createShelf()` handles this inline via the facade.
+
+---
+
+### Commit 3: `b4cc44a` — Remove BookcaseFacade dependency from ShelfService
+
+**Files changed:** 2 files, +3 lines, -12 lines
+
+`ShelfService` had been injecting `BookcaseFacade` to resolve bookcase labels inside `toShelfOption()`. That cross-service dependency was unnecessary for the core responsibility of `ShelfService` and introduced coupling between two peers in the stacks bounded context.
+
+**Removed:**
+- `BookcaseFacade` constructor injection from `ShelfService`
+- Bookcase label resolution from `toShelfOption()`
+- `bookcaseLabel` field from `ShelfOptionResponse`
+
+**ShelfOptionResponse before:**
+```java
+public record ShelfOptionResponse(
+    Long shelfId,
+    String shelfLabel,
+    String bookcaseLabel,
+    int bookCapacity,
+    long bookCount,
+    boolean hasSpace) {}
+```
+
+**ShelfOptionResponse after:**
+```java
+public record ShelfOptionResponse(
+    Long shelfId, String shelfLabel, int bookCapacity, long bookCount, boolean hasSpace) {}
+```
+
+The bookcase label field is now the caller's responsibility to resolve if needed — `ShelfService` stays within its own lane.
+
+---
+
+### Commit 4: `8175982` — Simplify ShelfService and trim test cases
+
+**Files changed:** 3 files, +48 lines, -149 lines
+
+Follow-up cleanup after the `BookcaseFacade` removal. The test suite had been written to verify facade interactions that no longer existed, so stale assertions and mocks were pruned. The `ShelfService` implementation was also tightened — commented-out bookcase resolution code from commit 3 was fully removed.
+
+**Net result:** `ShelfServiceTest` went from 286 lines down to ~130, focused entirely on validation behavior and repository interactions that are actually in scope.
+
+---
+
+## Architecture Before vs. After
+
+### Before
+
+```
+BookcaseService
+  ├── ShelfJpaRepository  (direct infra dependency)
+  └── ShelfFactory        (creates ShelfEntity directly)
+
+ShelfService
+  └── BookcaseFacade      (cross-service dep for label resolution)
+```
+
+### After
+
+```
+BookcaseService
+  └── ShelfFacade         (delegates through interface)
+
+ShelfService              (no cross-service deps)
+  └── ShelfJpaRepository  (owns its own persistence)
+```
+
+`ShelfFacade` is now the single entry point for shelf creation. `BookcaseService` expresses intent through the interface; `ShelfService` owns the implementation details.
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `ShelfFactory.java` (domain) | Deleted |
+| `ShelfFactory.java` (infrastructure) | Deleted |
+| `ShelfFacade.java` | Added `createShelf()` signature |
+| `ShelfService.java` | Added `createShelf()`, removed `BookcaseFacade`, removed `mapToDomain()` |
+| `ShelfOptionResponse.java` | Removed `bookcaseLabel` field |
+| `Shelf.java` | Reorganized, null-safety fix on `isFull()` |
+| `ShelfMapper.java` | Constructor-based mapping, removed dead `updateEntity()` |
+| `BookcaseService.java` | Delegates shelf creation via `ShelfFacade` |
+| `ShelfServiceTest.java` | Rewritten to match current implementation |
+| `BookcaseServiceTest.java` | Added (450 lines, comprehensive coverage) |
+
+---
+
+## Notes / Open Items
+
+- The anonymous initializer block in `ShelfService.createShelf()` is functional but unconventional — a builder or static factory method on `ShelfEntity` would be cleaner long-term
+- `toShelfOption()` now omits bookcase context — if consumers need that data, consider a richer projection or a separate query method rather than re-introducing the cross-service call
+- The `// todo: remove shelfLabel` and `// todo: remove shelfDescription` comments in `Shelf.java` are still pending — those fields have survived a few refactors; worth scheduling the removal before they get more entrenched
+
+---
+
+**Author:** leodvincci
+**Date:** Feb 18, 2026
+**Branch:** `refactor/shelf-factory-to-facade` → `main`

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
@@ -88,24 +88,8 @@ public class ShelfService implements ShelfFacade {
 
   @Override
   public void createShelf(Long bookcaseId, int position, String shelfLabel, int bookCapacity) {
-    if (bookCapacity <= 0) {
-      throw new IllegalArgumentException("Book capacity cannot be negative");
-    } else if (shelfLabel == null || shelfLabel.isBlank()) {
-      throw new IllegalArgumentException("Shelf label cannot be null or blank");
-    } else if (position < 0) {
-      throw new IllegalArgumentException("Shelf position cannot be negative");
-    }
-
     ShelfEntity shelfEntity =
-        shelfJpaRepository.save(
-            new ShelfEntity() {
-              {
-                setBookcaseId(bookcaseId);
-                setShelfPosition(position);
-                setShelfLabel(shelfLabel);
-                setBookCapacity(bookCapacity);
-              }
-            });
+        shelfJpaRepository.save(new ShelfEntity(bookcaseId, position, shelfLabel, bookCapacity));
     logger.info("Shelf created with ID: {} for bookcase: {}", shelfEntity.getShelfId(), bookcaseId);
   }
 

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/Shelf.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/Shelf.java
@@ -16,6 +16,16 @@ public class Shelf {
 
   // Constructor
   public Shelf(String shelfLabel, int shelfPosition, int bookCapacity, ShelfId shelfId) {
+    if (shelfLabel == null || shelfLabel.isBlank()) {
+      throw new IllegalArgumentException("Shelf label cannot be null or blank");
+    }
+    if (shelfPosition < 1) {
+      throw new IllegalArgumentException("Shelf position must be greater than 0");
+    }
+    if (bookCapacity < 1) {
+      throw new IllegalArgumentException("Book capacity cannot be negative");
+    }
+
     this.shelfLabel = shelfLabel;
     this.shelfPosition = shelfPosition;
     this.bookCapacity = bookCapacity;
@@ -52,14 +62,6 @@ public class Shelf {
     this.shelfLabel = shelfLabel;
   }
 
-  public String getLabel() {
-    return shelfLabel;
-  }
-
-  public void setLabel(String label) {
-    this.shelfLabel = label;
-  }
-
   public String getShelfDescription() {
     return shelfDescription;
   }
@@ -90,10 +92,6 @@ public class Shelf {
 
   public void setBookIds(List<Long> bookIds) {
     this.bookIds = bookIds;
-  }
-
-  public List<Long> getBooks() {
-    return bookIds;
   }
 
   public void setBooks(List<Long> books) {

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/entity/ShelfEntity.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/entity/ShelfEntity.java
@@ -2,68 +2,104 @@ package com.penrose.bibby.library.stacks.shelf.infrastructure.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.GenerationType;
 
 @Entity
 @Table(name = "shelves")
 public class ShelfEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Long shelfId;
-    private String shelfLabel;
-    private Long bookcaseId;
-    private int shelfPosition;
-    private int bookCapacity;
-    private String shelfDescription;
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long shelfId;
 
+  private String shelfLabel;
+  private Long bookcaseId;
+  private int shelfPosition;
+  private int bookCapacity;
+  private String shelfDescription;
 
-    public ShelfEntity() {
+  public ShelfEntity() {}
 
+  public ShelfEntity(Long bookcaseId, int shelfPosition, String shelfLabel, int bookCapacity) {
+    if (shelfLabel == null || shelfLabel.isBlank()) {
+      throw new IllegalArgumentException("Shelf label cannot be null or blank");
     }
-    public Long getBookcaseId() {
-        return bookcaseId;
+    if (shelfPosition < 1) {
+      throw new IllegalArgumentException("Shelf position must be greater than 0");
     }
-    public void setBookcaseId(Long bookCaseLabel) {
-        this.bookcaseId = bookCaseLabel;
+    if (bookCapacity < 1) {
+      throw new IllegalArgumentException("Book capacity cannot be negative");
     }
-    public String getShelfLabel() {
-        return shelfLabel;
+    if (bookcaseId == null) {
+      throw new IllegalArgumentException("Bookcase ID cannot be null");
     }
-    public void setShelfLabel(String label) {
-        this.shelfLabel = label;
-    }
-    public Long getShelfId() {
-        return shelfId;
-    }
-    public void setShelfId(Long id) {
-        this.shelfId = id;
-    }
-    public int getShelfPosition() {
-        return shelfPosition;
-    }
-    public void setShelfPosition(int shelfPosition) {
-        this.shelfPosition = shelfPosition;
+    if (bookcaseId < 1) {
+      throw new IllegalArgumentException("Bookcase ID must be greater than 0");
     }
 
-    public int getBookCapacity() {
-        return bookCapacity;
+    this.bookcaseId = bookcaseId;
+    this.shelfPosition = shelfPosition;
+    this.shelfLabel = shelfLabel;
+    this.bookCapacity = bookCapacity;
+  }
+
+  public Long getBookcaseId() {
+    return bookcaseId;
+  }
+
+  public void setBookcaseId(Long bookCaseLabel) {
+    if (bookCaseLabel < 1) {
+      throw new IllegalArgumentException("Bookcase ID must be greater than 0");
     }
+    this.bookcaseId = bookCaseLabel;
+  }
 
-    public void setBookCapacity(int shelfCapacity) {
-        this.bookCapacity = shelfCapacity;
+  public String getShelfLabel() {
+    return shelfLabel;
+  }
+
+  public void setShelfLabel(String label) {
+    this.shelfLabel = label;
+  }
+
+  public Long getShelfId() {
+    return shelfId;
+  }
+
+  public void setShelfId(Long id) {
+
+    this.shelfId = id;
+  }
+
+  public int getShelfPosition() {
+    return shelfPosition;
+  }
+
+  public void setShelfPosition(int shelfPosition) {
+    if (shelfPosition < 1) {
+      throw new IllegalArgumentException("Shelf position must be greater than 0");
     }
+    this.shelfPosition = shelfPosition;
+  }
 
+  public int getBookCapacity() {
+    return bookCapacity;
+  }
 
-    public String getShelfDescription() {
-        return shelfDescription;
+  public void setBookCapacity(int shelfCapacity) {
+    if (shelfCapacity < 1) {
+      throw new IllegalArgumentException("Book capacity cannot be negative");
     }
+    this.bookCapacity = shelfCapacity;
+  }
 
-    public void setShelfDescription(String shelfDescription) {
-        this.shelfDescription = shelfDescription;
-    }
+  public String getShelfDescription() {
+    return shelfDescription;
+  }
 
-
+  public void setShelfDescription(String shelfDescription) {
+    this.shelfDescription = shelfDescription;
+  }
 }

--- a/src/test/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfServiceTest.java
+++ b/src/test/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfServiceTest.java
@@ -136,7 +136,7 @@ class ShelfServiceTest {
   void createShelf_shouldThrowExceptionWhenPositionIsNegative() {
     assertThatThrownBy(() -> shelfService.createShelf(100L, -1, "Shelf A", 10))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Shelf position cannot be negative");
+        .hasMessage("Shelf position must be greater than 0");
 
     verify(shelfJpaRepository, never()).save(any(ShelfEntity.class));
   }
@@ -146,15 +146,12 @@ class ShelfServiceTest {
    * shelf is created with position zero (edge case).
    */
   @Test
-  void createShelf_shouldCreateShelfWithPositionZero() {
-    when(shelfJpaRepository.save(any(ShelfEntity.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+  void createShelf_shouldNotCreateShelfWithPositionZero() {
+    assertThatThrownBy(() -> shelfService.createShelf(100L, 0, "Shelf A", 10))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Shelf position must be greater than 0");
 
-    shelfService.createShelf(100L, 0, "Shelf A", 10);
-
-    verify(shelfJpaRepository)
-        .save(
-            argThat(shelf -> shelf.getShelfPosition() == 0 && shelf.getBookcaseId().equals(100L)));
+    verify(shelfJpaRepository, never()).save(any(ShelfEntity.class));
   }
 
   /**


### PR DESCRIPTION
This pull request implements a significant refactor of the shelf creation flow, focusing on enforcing validation at the domain and infrastructure levels, simplifying service logic, and cleaning up the codebase. The main improvements include moving input validation into constructors and setters, removing redundant or confusing methods, and updating tests to reflect the new validation rules. The result is stricter data integrity, less duplication, and a clearer separation of concerns.

**Validation and Domain Logic Improvements:**

* Added input validation to the `Shelf` and `ShelfEntity` constructors and setters to ensure that shelf labels are non-blank, positions and capacities are greater than zero, and bookcase IDs are valid. This prevents invalid objects from being created anywhere in the codebase. [[1]](diffhunk://#diff-733f7579affa8d20f88a2b66b8047af780afdc03c1120fafcb28a457bc445436R19-R28) [[2]](diffhunk://#diff-359f51404f9db8097db33ad4c1153b83e3bdbb3f71c7770feda15d93be30240fR16-R83) [[3]](diffhunk://#diff-359f51404f9db8097db33ad4c1153b83e3bdbb3f71c7770feda15d93be30240fR92-L68)
* Removed redundant or confusing getters and setters (e.g., `getLabel()`, `setLabel()`, `getBooks()`) from `Shelf`, reducing ambiguity and simplifying the domain model. [[1]](diffhunk://#diff-733f7579affa8d20f88a2b66b8047af780afdc03c1120fafcb28a457bc445436L55-L62) [[2]](diffhunk://#diff-733f7579affa8d20f88a2b66b8047af780afdc03c1120fafcb28a457bc445436L95-L98)

**Service Layer Simplification:**

* Updated `ShelfService.createShelf()` to delegate validation to the domain/infrastructure constructors, removing manual validation from the service layer and constructing `ShelfEntity` directly with validated arguments.

**Test Suite Updates:**

* Modified and expanded test cases to verify the new validation behavior, including ensuring that shelves with invalid positions (zero or negative) or blank labels throw exceptions and are not persisted. [[1]](diffhunk://#diff-dfd8ce240d48a26fc20a1654377e3000c8d7fdc3361b58fe0108700c02a8da3fL139-R139) [[2]](diffhunk://#diff-dfd8ce240d48a26fc20a1654377e3000c8d7fdc3361b58fe0108700c02a8da3fL149-R154)

**Other Codebase Cleanups:**

* Minor import order fixes and whitespace cleanups in `ShelfEntity`.

These changes collectively make shelf creation more robust, prevent invalid data from entering the system, and clarify the responsibilities of each layer.

---

…lf domain model

Context:
Following Domain-Driven Design principles, validation logic should be encapsulated within domain entities rather than scattered across service layers. This change consolidates validation rules into constructors and setters of Shelf and ShelfEntity, ensuring invariants are enforced at the domain boundary.

What changed:

Domain layer:
- Added constructor validation in Shelf for label, position, and capacity
- Removed duplicate getter methods (getLabel(), getBooks()) in favor of consistent naming (getShelfLabel(), getBookIds())
- Enforced business rule: shelf position must be >= 1

Infrastructure layer:
- Created parameterized constructor in ShelfEntity with full validation
- Added validation to all setters (position, capacity, bookcaseId)
- Added null and boundary checks for bookcaseId
- Improved code formatting and consistency

Application layer:
- Removed duplicate validation logic from ShelfService.createShelf()
- Simplified shelf creation by delegating to ShelfEntity constructor
- Reduced service method from ~20 lines to ~3 lines

Tests:
- Updated test assertions to match new validation messages
- Changed position=0 test from "should create" to "should not create"
- Verified all edge cases still properly reject invalid inputs

Documentation:
- Added devlog documenting the ShelfFactory to ShelfFacade refactor

Notes/Risks:
- Position validation now enforces >= 1 instead of >= 0 (business rule change)
- All validation now happens at construction/setter time, failing fast
- No database migrations required
- Existing valid data remains unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)