### PR TITLE
refactor: restructure Shelf domain model and decouple from Book modul…

### DIFF
--- a/src/main/java/com/penrose/bibby/library/cataloging/book/infrastructure/adapter/BookAccessAdapter.java
+++ b/src/main/java/com/penrose/bibby/library/cataloging/book/infrastructure/adapter/BookAccessAdapter.java
@@ -1,0 +1,31 @@
+package com.penrose.bibby.library.cataloging.book.infrastructure.adapter;
+
+import com.penrose.bibby.library.cataloging.book.core.domain.Book;
+import com.penrose.bibby.library.cataloging.book.core.domain.BookDomainRepository;
+import com.penrose.bibby.library.stacks.shelf.core.domain.ports.BookAccessPort;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapter that implements the Shelf module's BookAccessPort. This allows the Stacks context to
+ * access book data without depending on the Cataloging context's domain models.
+ *
+ * <p>Note: The dependency arrow points FROM Book TO Shelf's port interface, following the
+ * Dependency Inversion Principle.
+ */
+@Component
+public class BookAccessAdapter implements BookAccessPort {
+
+  private final BookDomainRepository bookDomainRepository;
+
+  public BookAccessAdapter(BookDomainRepository bookDomainRepository) {
+    this.bookDomainRepository = bookDomainRepository;
+  }
+
+  @Override
+  public List<Long> getBookIdsByShelfId(Long shelfId) {
+    List<Book> books = bookDomainRepository.getBooksByShelfId(shelfId);
+    return books.stream().map(book -> book.getBookId().getId()).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
@@ -7,7 +7,7 @@ import com.penrose.bibby.library.stacks.shelf.api.dtos.ShelfDTO;
 import com.penrose.bibby.library.stacks.shelf.api.dtos.ShelfOptionResponse;
 import com.penrose.bibby.library.stacks.shelf.api.dtos.ShelfSummary;
 import com.penrose.bibby.library.stacks.shelf.api.ports.inbound.ShelfFacade;
-import com.penrose.bibby.library.stacks.shelf.core.domain.Shelf;
+import com.penrose.bibby.library.stacks.shelf.core.domain.model.Shelf;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.entity.ShelfEntity;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.mapping.ShelfMapper;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.repository.ShelfJpaRepository;

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/ShelfDomainRepository.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/ShelfDomainRepository.java
@@ -1,5 +1,6 @@
 package com.penrose.bibby.library.stacks.shelf.core.domain;
 
+import com.penrose.bibby.library.stacks.shelf.core.domain.model.Shelf;
 import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
 
 public interface ShelfDomainRepository {

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/model/Shelf.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/model/Shelf.java
@@ -1,4 +1,4 @@
-package com.penrose.bibby.library.stacks.shelf.core.domain;
+package com.penrose.bibby.library.stacks.shelf.core.domain.model;
 
 import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
 import java.util.List;

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/ports/BookAccessPort.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/domain/ports/BookAccessPort.java
@@ -1,0 +1,21 @@
+package com.penrose.bibby.library.stacks.shelf.core.domain.ports;
+
+import java.util.List;
+
+/**
+ * Outbound port for accessing book information from the Cataloging context. This interface is owned
+ * by the Shelf module and defines what it needs from books in its own terms, following the
+ * Dependency Inversion Principle.
+ *
+ * <p>The Book module will provide an adapter that implements this interface.
+ */
+public interface BookAccessPort {
+
+  /**
+   * Retrieves the IDs of all books currently assigned to a specific shelf.
+   *
+   * @param shelfId The ID of the shelf
+   * @return List of book IDs on the shelf
+   */
+  List<Long> getBookIdsByShelfId(Long shelfId);
+}

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/adapter/outbound/ShelfDomainRepositoryImpl.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/adapter/outbound/ShelfDomainRepositoryImpl.java
@@ -1,14 +1,12 @@
 package com.penrose.bibby.library.stacks.shelf.infrastructure.adapter.outbound;
 
-import com.penrose.bibby.library.cataloging.book.core.domain.Book;
-import com.penrose.bibby.library.cataloging.book.core.domain.BookDomainRepository;
-import com.penrose.bibby.library.stacks.shelf.core.domain.Shelf;
 import com.penrose.bibby.library.stacks.shelf.core.domain.ShelfDomainRepository;
+import com.penrose.bibby.library.stacks.shelf.core.domain.model.Shelf;
+import com.penrose.bibby.library.stacks.shelf.core.domain.ports.BookAccessPort;
 import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.entity.ShelfEntity;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.mapping.ShelfMapper;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.repository.ShelfJpaRepository;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -17,35 +15,26 @@ public class ShelfDomainRepositoryImpl implements ShelfDomainRepository {
 
   private final ShelfJpaRepository jpaRepository;
   private final ShelfMapper shelfMapper;
-  private final BookDomainRepository bookDomainRepository;
-  private final ShelfJpaRepository shelfJpaRepository;
+  private final BookAccessPort bookAccessPort;
 
   public ShelfDomainRepositoryImpl(
-      ShelfJpaRepository jpaRepository,
-      ShelfMapper shelfMapper,
-      BookDomainRepository bookDomainRepository,
-      ShelfJpaRepository shelfJpaRepository) {
+      ShelfJpaRepository jpaRepository, ShelfMapper shelfMapper, BookAccessPort bookAccessPort) {
     this.jpaRepository = jpaRepository;
     this.shelfMapper = shelfMapper;
-    this.bookDomainRepository = bookDomainRepository;
-    this.shelfJpaRepository = shelfJpaRepository;
+    this.bookAccessPort = bookAccessPort;
   }
 
   @Override
   public Shelf getById(ShelfId id) {
     ShelfEntity entity = jpaRepository.findById(id.shelfId()).orElse(null);
-    List<Book> books = bookDomainRepository.getBooksByShelfId(id.shelfId());
-    List<Long> bookIds = new ArrayList<>();
-    for (Book book : books) {
-      bookIds.add(book.getBookId().getId());
-    }
+    List<Long> bookIds = bookAccessPort.getBookIdsByShelfId(id.shelfId());
     return shelfMapper.toDomainFromDTO(entity, bookIds);
   }
 
   @Override
   public void save(Shelf shelf) {
-    ShelfEntity entity = shelfJpaRepository.findById(shelf.getId()).get();
+    ShelfEntity entity = jpaRepository.findById(shelf.getId()).get();
     //        entity = shelfMapper.updateEntity(shelf);
-    shelfJpaRepository.save(entity);
+    jpaRepository.save(entity);
   }
 }

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/mapping/ShelfMapper.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/infrastructure/mapping/ShelfMapper.java
@@ -1,6 +1,6 @@
 package com.penrose.bibby.library.stacks.shelf.infrastructure.mapping;
 
-import com.penrose.bibby.library.stacks.shelf.core.domain.Shelf;
+import com.penrose.bibby.library.stacks.shelf.core.domain.model.Shelf;
 import com.penrose.bibby.library.stacks.shelf.core.domain.valueobject.ShelfId;
 import com.penrose.bibby.library.stacks.shelf.infrastructure.entity.ShelfEntity;
 import java.util.List;


### PR DESCRIPTION


Context:
This change improves the architectural boundaries within the Library domain by reorganizing the Shelf entity into a proper package structure and eliminating direct dependencies between the Shelf and Book bounded contexts. Previously, ShelfDomainRepositoryImpl had a direct dependency on BookDomainRepository, violating the Dependency Inversion Principle and creating tight coupling between modules.

What changed:

Domain Layer:
• Moved Shelf.java from core.domain/ to core.domain.model/ package for better organization • Created BookAccessPort interface in shelf/core/domain/ports/ (outbound port)
  - Defines what Shelf module needs from Book context in its own terms
  - Follows hexagonal architecture's port-adapter pattern

Infrastructure Layer:
• Updated ShelfDomainRepositoryImpl to depend on BookAccessPort instead of BookDomainRepository • Removed duplicate ShelfJpaRepository field (kept single jpaRepository reference) • Simplified book ID retrieval logic using the new port

Application/Mapping Layer:
• Updated all import statements across ShelfService, ShelfDomainRepository, and ShelfMapper
  to reflect the new Shelf location (core.domain.model.Shelf)

Cataloging (Book) Module:
• Created BookAccessAdapter in book/infrastructure/adapter/
  - Implements Shelf's BookAccessPort interface
  - Adapts Book domain's BookDomainRepository to Shelf's needs
  - Dependency arrow points FROM Book TO Shelf's port (DIP compliance)

Notes/Risks:
• This is a structural refactoring with no functional changes to business logic • The port-adapter pattern enables independent evolution of Shelf and Book modules • Future work: Consider similar decoupling for other cross-context dependencies • No database migrations required; changes are code-level only

🤖 Generated with [Claude Code](https://claude.com/claude-code)