### PR TITLE
Remove unused `bookMapper` method from `BookService`

### DIFF
--- a/src/main/java/com/penrose/bibby/library/cataloging/book/core/application/BookService.java
+++ b/src/main/java/com/penrose/bibby/library/cataloging/book/core/application/BookService.java
@@ -1,6 +1,5 @@
 package com.penrose.bibby.library.cataloging.book.core.application;
 
-import com.penrose.bibby.library.cataloging.author.api.dtos.AuthorDTO;
 import com.penrose.bibby.library.cataloging.book.api.dtos.*;
 import com.penrose.bibby.library.cataloging.book.core.domain.BookBuilder;
 import com.penrose.bibby.library.cataloging.book.core.domain.model.Book;


### PR DESCRIPTION
This pull request makes a minor change to the `BookService` class by removing the `bookMapper` method, which previously mapped a `BookDTO` and related DTOs to a domain object. This helps clean up unused or redundant code.

- Removed the `bookMapper` method from `BookService`, which mapped `BookDTO` and `AuthorDTO`/`ShelfDTO` objects to a domain `Book` object.