### PR TITLE
Make ShelfFacade and ShelfResponseMapper fields final in ShelfController

### DIFF
--- a/src/main/java/com/penrose/bibby/web/controllers/stacks/shelf/ShelfController.java
+++ b/src/main/java/com/penrose/bibby/web/controllers/stacks/shelf/ShelfController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ShelfController {
 
-  ShelfFacade shelfFacade;
-  ShelfResponseMapper shelfResponseMapper;
+  private final ShelfFacade shelfFacade;
+  private final ShelfResponseMapper shelfResponseMapper;
 
   public ShelfController(ShelfFacade shelfFacade, ShelfResponseMapper shelfResponseMapper) {
     this.shelfFacade = shelfFacade;


### PR DESCRIPTION
This pull request makes a small update to the `ShelfController` class, improving encapsulation and code clarity by marking its dependencies as `private final`. This change ensures that the fields cannot be modified after construction, which is a best practice for dependency injection in Spring controllers.