### PR TITLE
Rename findAllShelves to findShelvesByBookcaseId

### DIFF
--- a/src/main/java/com/penrose/bibby/cli/prompt/domain/PromptOptions.java
+++ b/src/main/java/com/penrose/bibby/cli/prompt/domain/PromptOptions.java
@@ -43,7 +43,7 @@ public class PromptOptions {
     Map<String, String> options = new LinkedHashMap<>();
     options.put("\u001B[38;5;202m[Cancel]\033[36m", "cancel");
     List<ShelfDTO> shelfDTOS =
-        shelfFacade.findAllShelves(bookcaseId).stream()
+        shelfFacade.findShelvesByBookcaseId(bookcaseId).stream()
             .map(
                 shelf -> {
                   return new ShelfDTO(
@@ -158,7 +158,7 @@ public class PromptOptions {
     for (BookcaseDTO bookcaseDTO : bookcaseDTOs) {
       int shelfBookCount = 0;
       List<ShelfDTO> shelves =
-          shelfFacade.findAllShelves(bookcaseDTO.bookcaseId()).stream()
+          shelfFacade.findShelvesByBookcaseId(bookcaseDTO.bookcaseId()).stream()
               .map(
                   shelf -> {
                     return new ShelfDTO(

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfService.java
@@ -27,8 +27,8 @@ public class ShelfService implements ShelfFacade {
   }
 
   @Override
-  public List<Shelf> findAllShelves(Long bookCaseId) {
-    return queryShelfUseCase.findAllShelves(bookCaseId);
+  public List<Shelf> findShelvesByBookcaseId(Long bookcaseId) {
+    return queryShelfUseCase.findShelvesByBookcaseId(bookcaseId);
   }
 
   @Override

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/usecases/QueryShelfUseCase.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/application/usecases/QueryShelfUseCase.java
@@ -18,7 +18,7 @@ public class QueryShelfUseCase {
     this.shelfDomainRepository = shelfDomainRepository;
   }
 
-  public List<Shelf> findAllShelves(Long bookcaseId) {
+  public List<Shelf> findShelvesByBookcaseId(Long bookcaseId) {
     return shelfDomainRepository.findByBookcaseId(bookcaseId);
   }
 

--- a/src/main/java/com/penrose/bibby/library/stacks/shelf/core/ports/inbound/ShelfFacade.java
+++ b/src/main/java/com/penrose/bibby/library/stacks/shelf/core/ports/inbound/ShelfFacade.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface ShelfFacade {
 
-  List<Shelf> findAllShelves(Long bookCaseId);
+  List<Shelf> findShelvesByBookcaseId(Long bookcaseId);
 
   Optional<Shelf> findShelfById(Long shelfId);
 

--- a/src/main/java/com/penrose/bibby/web/controllers/stacks/shelf/ShelfController.java
+++ b/src/main/java/com/penrose/bibby/web/controllers/stacks/shelf/ShelfController.java
@@ -35,7 +35,7 @@ public class ShelfController {
    */
   @GetMapping("/options/{bookcaseId}")
   public List<ShelfOptionResponse> getShelfOptionsByBookcase(@PathVariable Long bookcaseId) {
-    return shelfFacade.findAllShelves(bookcaseId).stream()
+    return shelfFacade.findShelvesByBookcaseId(bookcaseId).stream()
         .map(shelfResponseMapper::toShelfOption)
         .toList();
   }

--- a/src/test/java/com/penrose/bibby/cli/prompt/domain/PromptOptionsTest.java
+++ b/src/test/java/com/penrose/bibby/cli/prompt/domain/PromptOptionsTest.java
@@ -71,8 +71,8 @@ class PromptOptionsTest {
     BookcaseDTO bookcase2 = new BookcaseDTO(2L, 3, 15, "Office", "B", "2");
 
     when(bookcaseFacade.getAllBookcases()).thenReturn(List.of(bookcase1, bookcase2));
-    when(shelfFacade.findAllShelves(1L)).thenReturn(List.of());
-    when(shelfFacade.findAllShelves(2L)).thenReturn(List.of());
+    when(shelfFacade.findShelvesByBookcaseId(1L)).thenReturn(List.of());
+    when(shelfFacade.findShelvesByBookcaseId(2L)).thenReturn(List.of());
 
     Map<String, String> options = promptOptions.bookCaseOptions();
 
@@ -94,7 +94,7 @@ class PromptOptionsTest {
     Book book3 = buildBook(200L);
 
     when(bookcaseFacade.getAllBookcases()).thenReturn(List.of(bookcase));
-    when(shelfFacade.findAllShelves(1L)).thenReturn(List.of(shelf1, shelf2));
+    when(shelfFacade.findShelvesByBookcaseId(1L)).thenReturn(List.of(shelf1, shelf2));
     when(bookFacade.findByShelfId(10L)).thenReturn(List.of(book1, book2));
     when(bookFacade.findByShelfId(11L)).thenReturn(List.of(book3));
 
@@ -112,7 +112,7 @@ class PromptOptionsTest {
     BookcaseDTO bookcase = new BookcaseDTO(1L, 2, 10, "basement", "A", "1");
 
     when(bookcaseFacade.getAllBookcases()).thenReturn(List.of(bookcase));
-    when(shelfFacade.findAllShelves(1L)).thenReturn(List.of());
+    when(shelfFacade.findShelvesByBookcaseId(1L)).thenReturn(List.of());
 
     Map<String, String> options = promptOptions.bookCaseOptions();
 
@@ -128,7 +128,7 @@ class PromptOptionsTest {
     Shelf emptyShelf = new Shelf("Empty Shelf", 1, 10, new ShelfId(20L), new ArrayList<>(), 1L);
 
     when(bookcaseFacade.getAllBookcases()).thenReturn(List.of(bookcase));
-    when(shelfFacade.findAllShelves(1L)).thenReturn(List.of(emptyShelf));
+    when(shelfFacade.findShelvesByBookcaseId(1L)).thenReturn(List.of(emptyShelf));
     when(bookFacade.findByShelfId(20L)).thenReturn(List.of());
 
     Map<String, String> options = promptOptions.bookCaseOptions();
@@ -147,9 +147,9 @@ class PromptOptionsTest {
     BookcaseDTO bookcase3 = new BookcaseDTO(3L, 2, 10, "Gamma", "C", "3");
 
     when(bookcaseFacade.getAllBookcases()).thenReturn(List.of(bookcase1, bookcase2, bookcase3));
-    when(shelfFacade.findAllShelves(1L)).thenReturn(List.of());
-    when(shelfFacade.findAllShelves(2L)).thenReturn(List.of());
-    when(shelfFacade.findAllShelves(3L)).thenReturn(List.of());
+    when(shelfFacade.findShelvesByBookcaseId(1L)).thenReturn(List.of());
+    when(shelfFacade.findShelvesByBookcaseId(2L)).thenReturn(List.of());
+    when(shelfFacade.findShelvesByBookcaseId(3L)).thenReturn(List.of());
 
     Map<String, String> options = promptOptions.bookCaseOptions();
 

--- a/src/test/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfServiceTest.java
+++ b/src/test/java/com/penrose/bibby/library/stacks/shelf/core/application/ShelfServiceTest.java
@@ -25,15 +25,15 @@ class ShelfServiceTest {
   @InjectMocks private ShelfService shelfService;
 
   @Test
-  void findAllShelves_shouldDelegateToQueryUseCase() {
+  void findShelvesByBookcaseId_shouldDelegateToQueryUseCase() {
     Long bookcaseId = 100L;
     List<Shelf> expected = List.of(mock(Shelf.class));
-    when(queryShelfUseCase.findAllShelves(bookcaseId)).thenReturn(expected);
+    when(queryShelfUseCase.findShelvesByBookcaseId(bookcaseId)).thenReturn(expected);
 
-    List<Shelf> result = shelfService.findAllShelves(bookcaseId);
+    List<Shelf> result = shelfService.findShelvesByBookcaseId(bookcaseId);
 
     assertThat(result).isEqualTo(expected);
-    verify(queryShelfUseCase).findAllShelves(bookcaseId);
+    verify(queryShelfUseCase).findShelvesByBookcaseId(bookcaseId);
   }
 
   @Test

--- a/src/test/java/com/penrose/bibby/library/stacks/shelf/core/application/usecases/QueryShelfUseCaseTest.java
+++ b/src/test/java/com/penrose/bibby/library/stacks/shelf/core/application/usecases/QueryShelfUseCaseTest.java
@@ -22,39 +22,39 @@ class QueryShelfUseCaseTest {
   @InjectMocks private QueryShelfUseCase queryShelfUseCase;
 
   @Test
-  void findAllShelves_shouldReturnAllShelvesForBookcase() {
+  void findShelvesByBookcaseId_shouldReturnAllShelvesForBookcase() {
     Long bookcaseId = 100L;
     Shelf shelf1 = mock(Shelf.class);
     Shelf shelf2 = mock(Shelf.class);
 
     when(shelfDomainRepository.findByBookcaseId(bookcaseId)).thenReturn(List.of(shelf1, shelf2));
 
-    List<Shelf> result = queryShelfUseCase.findAllShelves(bookcaseId);
+    List<Shelf> result = queryShelfUseCase.findShelvesByBookcaseId(bookcaseId);
 
     assertThat(result).hasSize(2).containsExactly(shelf1, shelf2);
     verify(shelfDomainRepository).findByBookcaseId(bookcaseId);
   }
 
   @Test
-  void findAllShelves_shouldReturnEmptyListWhenBookcaseHasNoShelves() {
+  void findShelvesByBookcaseId_shouldReturnEmptyListWhenBookcaseHasNoShelves() {
     Long bookcaseId = 100L;
 
     when(shelfDomainRepository.findByBookcaseId(bookcaseId)).thenReturn(List.of());
 
-    List<Shelf> result = queryShelfUseCase.findAllShelves(bookcaseId);
+    List<Shelf> result = queryShelfUseCase.findShelvesByBookcaseId(bookcaseId);
 
     assertThat(result).isEmpty();
     verify(shelfDomainRepository).findByBookcaseId(bookcaseId);
   }
 
   @Test
-  void findAllShelves_shouldDelegateToRepository() {
+  void findShelvesByBookcaseId_shouldDelegateToRepository() {
     Long bookcaseId = 100L;
     Shelf shelf = mock(Shelf.class);
 
     when(shelfDomainRepository.findByBookcaseId(bookcaseId)).thenReturn(List.of(shelf));
 
-    List<Shelf> result = queryShelfUseCase.findAllShelves(bookcaseId);
+    List<Shelf> result = queryShelfUseCase.findShelvesByBookcaseId(bookcaseId);
 
     assertThat(result).containsExactly(shelf);
     verify(shelfDomainRepository).findByBookcaseId(bookcaseId);


### PR DESCRIPTION
Context:
- findAllShelves(Long bookCaseId) contradicts findAll() which truly has no filter
- Name did not follow the findXByY convention used by findShelfById and Spring Data
- Parameter was inconsistently cased (bookCaseId vs bookcaseId everywhere else)

What changed:
- Domain: ShelfFacade interface method renamed, param casing fixed
- Application: ShelfService and QueryShelfUseCase method renamed
- API: ShelfController call site updated
- Infrastructure: PromptOptions call sites updated (2 locations)
- Tests: ShelfServiceTest, QueryShelfUseCaseTest, PromptOptionsTest updated