### PR TITLE
Update BookImportController to use X-Forwarded-For for client IP in rate limiting

### DIFF
--- a/src/main/java/com/penrose/bibby/web/controllers/cataloging/book/BookImportController.java
+++ b/src/main/java/com/penrose/bibby/web/controllers/cataloging/book/BookImportController.java
@@ -33,9 +33,18 @@ public class BookImportController {
     if (request == null || request.isbn() == null || request.isbn().isBlank()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ISBN is required");
     }
-    String ip = servletRequest.getRemoteAddr();
-    log.info("USER IP Address: {} ", ip);
-    if (!rateLimitService.isAllowed(ip)) {
+    String xff = servletRequest.getHeader("X-Forwarded-For");
+
+    String clientIp;
+    if (xff != null && !xff.isBlank()) {
+      clientIp = xff.split(",")[0].trim();
+    } else {
+      clientIp = servletRequest.getRemoteAddr();
+    }
+
+    log.info("USER IP Address: {} ", clientIp);
+
+    if (!rateLimitService.isAllowed(clientIp)) {
       throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS);
     }
     log.info("Import request for ISBN {}", request.isbn());


### PR DESCRIPTION
This pull request updates the IP address extraction logic in the `importBook` endpoint to more accurately identify the client’s IP, especially when requests are proxied. The change ensures rate limiting and logging use the correct client IP.

Improvements to client IP extraction and rate limiting:

* Updated the code in `BookImportController.java` to extract the client IP from the `X-Forwarded-For` header if present, falling back to `getRemoteAddr()` otherwise, and use this value for both logging and rate limiting checks.